### PR TITLE
Fiks arbeidsforhold sync pga data tap i Aareg

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/clients/pdl/PdlEksternClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/clients/pdl/PdlEksternClient.kt
@@ -36,6 +36,7 @@ class PdlEksternClient(
                               }
                             }
                             """.trimIndent(),
+                        operationName = "HentIdenterMedHistorikk",
                         variables = Collections.singletonMap("ident", ident),
                     ),
                 headers =
@@ -71,6 +72,7 @@ class PdlEksternClient(
                               }
                             }
                             """.trimIndent(),
+                        operationName = "HentPersonNavn",
                         variables = Collections.singletonMap("ident", fnr),
                     ),
                 headers =
@@ -109,6 +111,7 @@ class PdlEksternClient(
                               }
                             }
                             """.trimIndent(),
+                        operationName = "HentPersonFoedselsdato",
                         variables = Collections.singletonMap("ident", fnr),
                     ),
                 headers =

--- a/src/main/kotlin/no/nav/helse/flex/clients/pdl/PdlGraphQl.kt
+++ b/src/main/kotlin/no/nav/helse/flex/clients/pdl/PdlGraphQl.kt
@@ -55,6 +55,7 @@ class PdlGraphQlClient(
 data class GraphQlRequest(
     val query: String,
     val variables: Map<String, String>,
+    val operationName: String? = null,
 )
 
 data class GraphQlResponse<out T : Any>(

--- a/src/main/kotlin/no/nav/helse/flex/listeners/aareghendelser/AaregHendelserConsumer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/listeners/aareghendelser/AaregHendelserConsumer.kt
@@ -63,19 +63,8 @@ class AaregHendelserConsumer(
 
         when (hendelseHandtering) {
             AaregHendelseHandtering.OPPRETT_OPPDATER -> {
-                val resultat = arbeidsforholdInnhentingService.synkroniserArbeidsforholdForPerson(fnr)
-                log.info(
-                    "Arbeidsforhold synkronisert ved aareg hendelse: " +
-                        "Opprettet{${resultat.skalOpprettes.count()}, navArbeidsforholdId: ${resultat.skalOpprettes.map {
-                            it.navArbeidsforholdId
-                        }}}, " +
-                        "Oppdaterte{${resultat.skalOppdateres.count()}, navArbeidsforholdId: ${resultat.skalOppdateres.map {
-                            it.navArbeidsforholdId
-                        }}}, " +
-                        "Slettet{${resultat.skalSlettes.count()}, navArbeidsforholdId: ${resultat.skalSlettes.map {
-                            it.navArbeidsforholdId
-                        }}}",
-                )
+                log.info("Synkroniserer arbeidsforhold ved aareg hendelse")
+                arbeidsforholdInnhentingService.synkroniserArbeidsforholdForPerson(fnr)
             }
 
             AaregHendelseHandtering.SLETT -> {

--- a/src/test/kotlin/no/nav/helse/flex/arbeidsforhold/ArbeidsforholdRepositoryFake.kt
+++ b/src/test/kotlin/no/nav/helse/flex/arbeidsforhold/ArbeidsforholdRepositoryFake.kt
@@ -6,6 +6,10 @@ class ArbeidsforholdRepositoryFake :
     AbstractCrudRepositoryFake<Arbeidsforhold>(
         getEntityId = { it.id },
         setEntityId = { entity, id -> entity.copy(id = id) },
+        uniqueConstraints =
+            listOf(
+                Arbeidsforhold::navArbeidsforholdId,
+            ),
     ),
     ArbeidsforholdRepository {
     override fun findByNavArbeidsforholdId(navArbeidsforholdId: String): Arbeidsforhold? =

--- a/src/test/kotlin/no/nav/helse/flex/arbeidsforhold/innhenting/AaregTestData.kt
+++ b/src/test/kotlin/no/nav/helse/flex/arbeidsforhold/innhenting/AaregTestData.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.helse.flex.clients.aareg.ArbeidsforholdOversikt
 import no.nav.helse.flex.clients.aareg.ArbeidsforholdoversiktResponse
 import no.nav.helse.flex.utils.objectMapper
+import java.time.LocalDate
 
 fun lagArbeidsforholdOversiktResponse(
     arbeidsforholdoversikter: List<ArbeidsforholdOversikt> = listOf(lagArbeidsforholdOversikt()),
@@ -13,21 +14,25 @@ fun lagArbeidsforholdOversiktResponse(
     )
 
 fun lagArbeidsforholdOversikt(
-    identer: List<String> = listOf("2175141353812"),
-    orgnummer: String = "910825518",
     navArbeidsforholdId: String = "navArbeidsforholdId",
+    typeKode: String = "ordinaertArbeidsforhold",
+    arbeidstakerIdenter: List<String> = listOf("2175141353812"),
+    arbeidsstedOrgnummer: String = "910825518",
+    opplysningspliktigOrgnummer: String = "810825472",
+    startdato: LocalDate = LocalDate.parse("2014-01-01"),
+    sluttdato: LocalDate? = null,
 ): ArbeidsforholdOversikt =
     objectMapper.readValue(
         """
             {
           "type": {
-            "kode": "ordinaertArbeidsforhold",
+            "kode": "$typeKode",
             "beskrivelse": "Ordinært arbeidsforhold"
           },
           "arbeidstaker": {
             "identer": [
             ${
-            identer.joinToString(",\n") {
+            arbeidstakerIdenter.joinToString(",\n") {
                 """
                 {
                   "type": "FOLKEREGISTERIDENT",
@@ -44,7 +49,7 @@ fun lagArbeidsforholdOversikt(
             "identer": [
               {
                 "type": "ORGANISASJONSNUMMER",
-                "ident": "$orgnummer"
+                "ident": "$arbeidsstedOrgnummer"
               }
             ]
           },
@@ -53,11 +58,12 @@ fun lagArbeidsforholdOversikt(
             "identer": [
               {
                 "type": "ORGANISASJONSNUMMER",
-                "ident": "810825472"
+                "ident": "$opplysningspliktigOrgnummer"
               }
             ]
           },
-          "startdato": "2014-01-01",
+          "startdato": "$startdato",
+          "sluttdato": ${sluttdato?.let { "\"$it\"" }},
           "yrke": {
             "kode": "1231119",
             "beskrivelse": "KONTORLEDER"

--- a/src/test/kotlin/no/nav/helse/flex/arbeidsgiverdetaljer/ArbeidsgiverDetaljerHenterFakeTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/arbeidsgiverdetaljer/ArbeidsgiverDetaljerHenterFakeTest.kt
@@ -52,8 +52,8 @@ class ArbeidsgiverDetaljerHenterFakeTest : FakesTestOppsett() {
     fun `burde hente riktig arbeidsgiverDetaljer for person`() {
         arbeidsforholdRepository.saveAll(
             listOf(
-                lagArbeidsforhold(fnr = "1", orgnummer = "org1"),
-                lagArbeidsforhold(fnr = "2", orgnummer = "org2"),
+                lagArbeidsforhold(fnr = "1", orgnummer = "org1", navArbeidsforholdId = "1"),
+                lagArbeidsforhold(fnr = "2", orgnummer = "org2", navArbeidsforholdId = "2"),
             ),
         )
         narmesteLederRepository.saveAll(

--- a/src/test/kotlin/no/nav/helse/flex/clients/pdl/PdlClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/clients/pdl/PdlClientTest.kt
@@ -45,11 +45,12 @@ class PdlClientTest {
 
             pdlClient.hentIdenterMedHistorikk(ident = "ident")
 
-            recordedRequest.shouldNotBeNull()
-            recordedRequest.headers["Tema"] `should be equal to` "SYK"
-            recordedRequest.headers["Behandlingsnummer"] `should be equal to` "B229"
-            recordedRequest.headers["Content-Type"] `should be equal to` "application/json"
-            val parsedBody: GraphQlRequest = objectMapper.readValue(recordedRequest.body.readUtf8())
+            val request = recordedRequest.shouldNotBeNull()
+            request.shouldNotBeNull()
+            request.headers["Tema"] `should be equal to` "SYK"
+            request.headers["Behandlingsnummer"] `should be equal to` "B229"
+            request.headers["Content-Type"] `should be equal to` "application/json"
+            val parsedBody: GraphQlRequest = objectMapper.readValue(request.body.readUtf8())
             parsedBody.query shouldBeGraphQlQueryEqualTo
                 """
                 query(${"$"}ident: ID!) {
@@ -63,7 +64,7 @@ class PdlClientTest {
                 """
             parsedBody.variables `should be equal to` mapOf("ident" to "ident")
 
-            recordedRequest.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+            request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
         }
 
         @Test
@@ -116,11 +117,11 @@ class PdlClientTest {
 
             pdlClient.hentFormattertNavn("fnr")
 
-            recordedRequest.shouldNotBeNull()
-            recordedRequest.headers["Behandlingsnummer"] `should be equal to` "B229"
-            recordedRequest.headers["Tema"] `should be equal to` "SYK"
-            recordedRequest.headers["Content-Type"] `should be equal to` "application/json"
-            val parsedBody: GraphQlRequest = objectMapper.readValue(recordedRequest.body.readUtf8())
+            val request = recordedRequest.shouldNotBeNull()
+            request.headers["Behandlingsnummer"] `should be equal to` "B229"
+            request.headers["Tema"] `should be equal to` "SYK"
+            request.headers["Content-Type"] `should be equal to` "application/json"
+            val parsedBody: GraphQlRequest = objectMapper.readValue(request.body.readUtf8())
             parsedBody.query shouldBeGraphQlQueryEqualTo
                 """
             query(${'$'}ident: ID!) {
@@ -135,7 +136,7 @@ class PdlClientTest {
             """
             parsedBody.variables `should be equal to` mapOf("ident" to "fnr")
 
-            recordedRequest.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+            request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
         }
 
         @Test
@@ -192,11 +193,11 @@ class PdlClientTest {
 
             pdlClient.hentFoedselsdato("fnr")
 
-            recordedRequest.shouldNotBeNull()
-            recordedRequest.headers["Behandlingsnummer"] `should be equal to` "B229"
-            recordedRequest.headers["Tema"] `should be equal to` "SYK"
-            recordedRequest.headers["Content-Type"] `should be equal to` "application/json"
-            val parsedBody: GraphQlRequest = objectMapper.readValue(recordedRequest.body.readUtf8())
+            val request = recordedRequest.shouldNotBeNull()
+            request.headers["Behandlingsnummer"] `should be equal to` "B229"
+            request.headers["Tema"] `should be equal to` "SYK"
+            request.headers["Content-Type"] `should be equal to` "application/json"
+            val parsedBody: GraphQlRequest = objectMapper.readValue(request.body.readUtf8())
             parsedBody.query shouldBeGraphQlQueryEqualTo
                 """
                 query(${"$"}ident: ID!) {
@@ -209,7 +210,7 @@ class PdlClientTest {
             """
             parsedBody.variables `should be equal to` mapOf("ident" to "fnr")
 
-            recordedRequest.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+            request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
         }
 
         @Test

--- a/src/test/kotlin/no/nav/helse/flex/sykmelding/application/SykmeldingKafkaLagrerTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/sykmelding/application/SykmeldingKafkaLagrerTest.kt
@@ -152,7 +152,9 @@ class SykmeldingKafkaLagrerTest : FakesTestOppsett() {
     @Test
     fun `burde hente arbeidsforhold nar sykmelding lagres`() {
         aaregClient.setArbeidsforholdoversikt(
-            lagArbeidsforholdOversiktResponse(listOf(lagArbeidsforholdOversikt(identer = listOf("fnr"), orgnummer = "910825518"))),
+            lagArbeidsforholdOversiktResponse(
+                listOf(lagArbeidsforholdOversikt(arbeidstakerIdenter = listOf("fnr"), arbeidsstedOrgnummer = "910825518")),
+            ),
             "fnr",
         )
         eregClient.setNokkelinfo(failure = RuntimeException())


### PR DESCRIPTION
Også:
- Refaktorer tester som brukte Mock
- La Pdl respons i mock webserver returnere default verdier
- Legg til unique constraint på navArbeidsforholdId i ArbeidsforholdRepositoryFake
- Lagt til rette for å spesifisere unique constraints i AbstractCrudRepositoryFake