### PR TITLE
Legg til glemte felter på arbeidsgiverInfo i sykmelding grunnlag (tsm sykmelding)

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/api/SykmeldingDtoKonverterer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/api/SykmeldingDtoKonverterer.kt
@@ -445,6 +445,11 @@ fun ArbeidsgiverInfo.getTiltakArbeidsplassen(): String? =
 
 fun ArbeidsgiverInfo.tilArbeidsgiverDTO(): ArbeidsgiverDTO? =
     when (this) {
+        is EnArbeidsgiver ->
+            ArbeidsgiverDTO(
+                navn = this.navn,
+                stillingsprosent = this.stillingsprosent,
+            )
         is FlereArbeidsgivere ->
             ArbeidsgiverDTO(
                 navn = this.navn,

--- a/src/main/kotlin/no/nav/helse/flex/sykmelding/domain/tsm/ArbeidsgiverInfo.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sykmelding/domain/tsm/ArbeidsgiverInfo.kt
@@ -13,6 +13,9 @@ sealed interface ArbeidsgiverInfo {
 }
 
 data class EnArbeidsgiver(
+    val navn: String?,
+    val yrkesbetegnelse: String?,
+    val stillingsprosent: Int?,
     val meldingTilArbeidsgiver: String?,
     val tiltakArbeidsplassen: String?,
 ) : ArbeidsgiverInfo {

--- a/src/test/kotlin/no/nav/helse/flex/api/SykmeldingDtoKonvertererTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/api/SykmeldingDtoKonvertererTest.kt
@@ -284,14 +284,21 @@ class SykmeldingDtoKonvertererTest : FakesTestOppsett() {
     }
 
     @Test
-    fun `burde konvertere arbeidsgiver, en arbeidsgiver har ikke info`() {
+    fun `burde konvertere arbeidsgiver, en arbeidsgiver`() {
         val enArbeidsgiver =
             EnArbeidsgiver(
+                navn = "Navn",
+                yrkesbetegnelse = "_",
+                stillingsprosent = 50,
                 meldingTilArbeidsgiver = "_",
                 tiltakArbeidsplassen = "_",
             )
 
-        enArbeidsgiver.tilArbeidsgiverDTO().`should be null`()
+        enArbeidsgiver.tilArbeidsgiverDTO() shouldBeEqualTo
+            ArbeidsgiverDTO(
+                navn = "Navn",
+                stillingsprosent = 50,
+            )
     }
 
     @Test
@@ -489,6 +496,9 @@ class SykmeldingDtoKonvertererTest : FakesTestOppsett() {
     @Test
     fun `burde konvertere tiltak arbeidsplassen`() {
         EnArbeidsgiver(
+            navn = "_",
+            yrkesbetegnelse = "_",
+            stillingsprosent = 0,
             meldingTilArbeidsgiver = "_",
             tiltakArbeidsplassen = "tiltak",
         ).getTiltakArbeidsplassen() `should be equal to` "tiltak"
@@ -509,6 +519,9 @@ class SykmeldingDtoKonvertererTest : FakesTestOppsett() {
         EnArbeidsgiver(
             meldingTilArbeidsgiver = "Melding",
             tiltakArbeidsplassen = "_",
+            navn = "_",
+            yrkesbetegnelse = "_",
+            stillingsprosent = 0,
         ).getMeldingTilArbeidsgiver() `should be equal to` "Melding"
 
         FlereArbeidsgivere(


### PR DESCRIPTION
sykmeldingGrunnlag->arbeidsgiverInfo->EnArbeidsgiver legg til navn, yrkesbetegnelse, stillingsprosent