### PR TITLE
legg til UtdatertFormatBrukerSvar

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/api/SykmeldingStatusDtoKonverterer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/api/SykmeldingStatusDtoKonverterer.kt
@@ -50,7 +50,7 @@ class SykmeldingStatusDtoKonverterer {
             is ArbeidstakerBrukerSvar ->
                 SykmeldingSporsmalSvarDto(
                     erOpplysningeneRiktige = brukerSvar.erOpplysningeneRiktige.tilJaEllerNeiFormSvar(),
-                    arbeidssituasjon = brukerSvar.arbeidssituasjonSporsmal.tilArbeidssituasjonFormSvar(),
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.tilArbeidssituasjonFormSvar(),
                     uriktigeOpplysninger = brukerSvar.uriktigeOpplysninger?.tilUriktigeOpplysningerFormSvar(),
                     arbeidsgiverOrgnummer = brukerSvar.arbeidsgiverOrgnummer.tilFritekstFormSvar(),
                     riktigNarmesteLeder = brukerSvar.riktigNarmesteLeder?.tilJaEllerNeiFormSvar(),
@@ -61,20 +61,20 @@ class SykmeldingStatusDtoKonverterer {
             is AnnetArbeidssituasjonBrukerSvar ->
                 SykmeldingSporsmalSvarDto(
                     erOpplysningeneRiktige = brukerSvar.erOpplysningeneRiktige.tilJaEllerNeiFormSvar(),
-                    arbeidssituasjon = brukerSvar.arbeidssituasjonSporsmal.tilArbeidssituasjonFormSvar(),
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.tilArbeidssituasjonFormSvar(),
                     uriktigeOpplysninger = brukerSvar.uriktigeOpplysninger?.tilUriktigeOpplysningerFormSvar(),
                 )
             is ArbeidsledigBrukerSvar ->
                 SykmeldingSporsmalSvarDto(
                     erOpplysningeneRiktige = brukerSvar.erOpplysningeneRiktige.tilJaEllerNeiFormSvar(),
-                    arbeidssituasjon = brukerSvar.arbeidssituasjonSporsmal.tilArbeidssituasjonFormSvar(),
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.tilArbeidssituasjonFormSvar(),
                     arbeidsgiverOrgnummer = brukerSvar.arbeidsledigFraOrgnummer?.tilFritekstFormSvar(),
                     uriktigeOpplysninger = brukerSvar.uriktigeOpplysninger?.tilUriktigeOpplysningerFormSvar(),
                 )
             is PermittertBrukerSvar ->
                 SykmeldingSporsmalSvarDto(
                     erOpplysningeneRiktige = brukerSvar.erOpplysningeneRiktige.tilJaEllerNeiFormSvar(),
-                    arbeidssituasjon = brukerSvar.arbeidssituasjonSporsmal.tilArbeidssituasjonFormSvar(),
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.tilArbeidssituasjonFormSvar(),
                     arbeidsgiverOrgnummer = brukerSvar.arbeidsledigFraOrgnummer?.tilFritekstFormSvar(),
                     uriktigeOpplysninger = brukerSvar.uriktigeOpplysninger?.tilUriktigeOpplysningerFormSvar(),
                 )
@@ -82,7 +82,7 @@ class SykmeldingStatusDtoKonverterer {
                 SykmeldingSporsmalSvarDto(
                     erOpplysningeneRiktige = brukerSvar.erOpplysningeneRiktige.tilJaEllerNeiFormSvar(),
                     uriktigeOpplysninger = brukerSvar.uriktigeOpplysninger?.tilUriktigeOpplysningerFormSvar(),
-                    arbeidssituasjon = brukerSvar.arbeidssituasjonSporsmal.tilArbeidssituasjonFormSvar(),
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.tilArbeidssituasjonFormSvar(),
                     arbeidsgiverOrgnummer = brukerSvar.arbeidsgiverOrgnummer?.tilFritekstFormSvar(),
                     riktigNarmesteLeder = brukerSvar.riktigNarmesteLeder?.tilJaEllerNeiFormSvar(),
                     egenmeldingsdager = brukerSvar.egenmeldingsdager?.tilDatolisteFormSvar(),
@@ -100,7 +100,7 @@ class SykmeldingStatusDtoKonverterer {
                 SykmeldingSporsmalSvarDto(
                     erOpplysningeneRiktige = brukerSvar.erOpplysningeneRiktige.tilJaEllerNeiFormSvar(),
                     uriktigeOpplysninger = brukerSvar.uriktigeOpplysninger?.tilUriktigeOpplysningerFormSvar(),
-                    arbeidssituasjon = brukerSvar.arbeidssituasjonSporsmal.tilArbeidssituasjonFormSvar(),
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.tilArbeidssituasjonFormSvar(),
                     harBruktEgenmelding = brukerSvar.harBruktEgenmelding?.tilJaEllerNeiFormSvar(),
                     egenmeldingsperioder = brukerSvar.egenmeldingsperioder?.tilEgenmeldingsperioderFormSvar(),
                     harForsikring = brukerSvar.harForsikring?.tilJaEllerNeiFormSvar(),
@@ -109,7 +109,7 @@ class SykmeldingStatusDtoKonverterer {
                 SykmeldingSporsmalSvarDto(
                     erOpplysningeneRiktige = brukerSvar.erOpplysningeneRiktige.tilJaEllerNeiFormSvar(),
                     uriktigeOpplysninger = brukerSvar.uriktigeOpplysninger?.tilUriktigeOpplysningerFormSvar(),
-                    arbeidssituasjon = brukerSvar.arbeidssituasjonSporsmal.tilArbeidssituasjonFormSvar(),
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.tilArbeidssituasjonFormSvar(),
                     harBruktEgenmelding = brukerSvar.harBruktEgenmelding?.tilJaEllerNeiFormSvar(),
                     egenmeldingsperioder = brukerSvar.egenmeldingsperioder?.tilEgenmeldingsperioderFormSvar(),
                     harForsikring = brukerSvar.harForsikring?.tilJaEllerNeiFormSvar(),
@@ -118,11 +118,12 @@ class SykmeldingStatusDtoKonverterer {
                 SykmeldingSporsmalSvarDto(
                     erOpplysningeneRiktige = brukerSvar.erOpplysningeneRiktige.tilJaEllerNeiFormSvar(),
                     uriktigeOpplysninger = brukerSvar.uriktigeOpplysninger?.tilUriktigeOpplysningerFormSvar(),
-                    arbeidssituasjon = brukerSvar.arbeidssituasjonSporsmal.tilArbeidssituasjonFormSvar(),
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.tilArbeidssituasjonFormSvar(),
                     harBruktEgenmelding = brukerSvar.harBruktEgenmelding?.tilJaEllerNeiFormSvar(),
                     egenmeldingsperioder = brukerSvar.egenmeldingsperioder?.tilEgenmeldingsperioderFormSvar(),
                     harForsikring = brukerSvar.harForsikring?.tilJaEllerNeiFormSvar(),
                 )
+            is UtdatertFormatBrukerSvar -> error("Ikke implementert for UtdatertFormatBrukerSvar")
         }
 
     private fun SporsmalSvar<Boolean>.tilJaEllerNeiFormSvar(): FormSporsmalSvar<JaEllerNei> =

--- a/src/main/kotlin/no/nav/helse/flex/api/dto/SendSykmeldingRequestDTO.kt
+++ b/src/main/kotlin/no/nav/helse/flex/api/dto/SendSykmeldingRequestDTO.kt
@@ -25,7 +25,7 @@ data class SendSykmeldingRequestDTO(
             Arbeidssituasjon.ARBEIDSTAKER -> {
                 requireNotNull(arbeidsgiverOrgnummer) { "$arbeidssituasjon må ha satt arbeidsgiverOrgnummer" }
                 ArbeidstakerBrukerSvar(
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     erOpplysningeneRiktige = SporsmalSvar(erOpplysningeneRiktige.sporsmaltekst, erOpplysningeneRiktige.svar.tilBoolean()),
                     uriktigeOpplysninger =
                         uriktigeOpplysninger?.let {
@@ -44,7 +44,7 @@ data class SendSykmeldingRequestDTO(
                     }
 
                 ArbeidsledigBrukerSvar(
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     erOpplysningeneRiktige = SporsmalSvar(erOpplysningeneRiktige.sporsmaltekst, erOpplysningeneRiktige.svar.tilBoolean()),
                     arbeidsledigFraOrgnummer = arbeidsledigFraOrgnummer,
                     uriktigeOpplysninger =
@@ -61,7 +61,7 @@ data class SendSykmeldingRequestDTO(
                     }
 
                 PermittertBrukerSvar(
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     erOpplysningeneRiktige = SporsmalSvar(erOpplysningeneRiktige.sporsmaltekst, erOpplysningeneRiktige.svar.tilBoolean()),
                     arbeidsledigFraOrgnummer = arbeidsledigFraOrgnummer,
                     uriktigeOpplysninger =
@@ -75,7 +75,7 @@ data class SendSykmeldingRequestDTO(
                 requireNotNull(fisker) { "$arbeidssituasjon må ha satt fisker" }
 
                 FiskerBrukerSvar(
-                    arbeidssituasjonSporsmal = SporsmalSvar(arbeidssituasjon.sporsmaltekst, arbeidssituasjon.svar),
+                    arbeidssituasjon = SporsmalSvar(arbeidssituasjon.sporsmaltekst, arbeidssituasjon.svar),
                     erOpplysningeneRiktige =
                         SporsmalSvar(
                             erOpplysningeneRiktige.sporsmaltekst,
@@ -128,7 +128,7 @@ data class SendSykmeldingRequestDTO(
 
             Arbeidssituasjon.FRILANSER -> {
                 FrilanserBrukerSvar(
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     erOpplysningeneRiktige =
                         SporsmalSvar(
                             erOpplysningeneRiktige.sporsmaltekst,
@@ -154,7 +154,7 @@ data class SendSykmeldingRequestDTO(
             }
             Arbeidssituasjon.NAERINGSDRIVENDE -> {
                 NaringsdrivendeBrukerSvar(
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     erOpplysningeneRiktige = SporsmalSvar(erOpplysningeneRiktige.sporsmaltekst, erOpplysningeneRiktige.svar.tilBoolean()),
                     uriktigeOpplysninger =
                         uriktigeOpplysninger?.let {
@@ -170,7 +170,7 @@ data class SendSykmeldingRequestDTO(
             }
             Arbeidssituasjon.JORDBRUKER -> {
                 JordbrukerBrukerSvar(
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     erOpplysningeneRiktige = SporsmalSvar(erOpplysningeneRiktige.sporsmaltekst, erOpplysningeneRiktige.svar.tilBoolean()),
                     uriktigeOpplysninger =
                         uriktigeOpplysninger?.let {
@@ -186,7 +186,7 @@ data class SendSykmeldingRequestDTO(
             }
             Arbeidssituasjon.ANNET -> {
                 AnnetArbeidssituasjonBrukerSvar(
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     erOpplysningeneRiktige = SporsmalSvar(erOpplysningeneRiktige.sporsmaltekst, erOpplysningeneRiktige.svar.tilBoolean()),
                     uriktigeOpplysninger =
                         uriktigeOpplysninger?.let {

--- a/src/main/kotlin/no/nav/helse/flex/sykmelding/application/SykmeldingHandterer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sykmelding/application/SykmeldingHandterer.kt
@@ -71,6 +71,9 @@ class SykmeldingHandterer(
                 -> {
                     HendelseStatus.SENDT_TIL_NAV
                 }
+                is UtdatertFormatBrukerSvar -> throw IllegalArgumentException(
+                    "Kan ikke sende sykmelding med bruker svar av type ${brukerSvar.type}",
+                )
             }
 
         sykmeldingStatusEndrer.sjekkStatusEndring(sykmelding = sykmelding, nyStatus = nyStatus)

--- a/src/main/kotlin/no/nav/helse/flex/sykmelding/application/TilleggsinfoSammenstillerService.kt
+++ b/src/main/kotlin/no/nav/helse/flex/sykmelding/application/TilleggsinfoSammenstillerService.kt
@@ -53,6 +53,9 @@ class TilleggsinfoSammenstillerService(
             is JordbrukerBrukerSvar -> JordbrukerTilleggsinfo
             is NaringsdrivendeBrukerSvar -> NaringsdrivendeTilleggsinfo
             is AnnetArbeidssituasjonBrukerSvar -> AnnetArbeidssituasjonTilleggsinfo
+            is UtdatertFormatBrukerSvar -> throw IllegalArgumentException(
+                "Kan ikke sammenstille tilleggsinfo for bruker svar av type: ${brukerSvar.type}",
+            )
         }
 
     fun sammenstillArbeidsledigTilleggsinfo(

--- a/src/main/kotlin/no/nav/helse/flex/tsmsykmeldingstatus/SykmeldingHendelseFraKafkaKonverterer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/tsmsykmeldingstatus/SykmeldingHendelseFraKafkaKonverterer.kt
@@ -41,7 +41,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
         val tilleggsinfo =
             brukerSvar?.let { brukerSvar ->
                 konverterTilTilleggsinfo(
-                    arbeidssituasjon = brukerSvar.arbeidssituasjon,
+                    arbeidssituasjon = brukerSvar.arbeidssituasjon.svar,
                     arbeidsgiver = status.arbeidsgiver,
                     tidligereArbeidsgiver = status.tidligereArbeidsgiver,
                 )
@@ -214,7 +214,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
                 requireNotNull(arbeidsgiverOrgnummer) { "Arbeidsgiver orgnummer er påkrevd for ARBEIDSTAKER" }
                 ArbeidstakerBrukerSvar(
                     erOpplysningeneRiktige = erOpplysningeneRiktige,
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     uriktigeOpplysninger = uriktigeOpplysninger,
                     arbeidsgiverOrgnummer = arbeidsgiverOrgnummer,
                     riktigNarmesteLeder = riktigNarmesteLeder,
@@ -227,7 +227,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
                 requireNotNull(blad) { "Blad er påkrevd for FISKER" }
                 FiskerBrukerSvar(
                     erOpplysningeneRiktige = erOpplysningeneRiktige,
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     lottOgHyre = lottOgHyre,
                     blad = blad,
                     arbeidsgiverOrgnummer = arbeidsgiverOrgnummer,
@@ -244,7 +244,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
             ArbeidssituasjonDTO.FRILANSER -> {
                 FrilanserBrukerSvar(
                     erOpplysningeneRiktige = erOpplysningeneRiktige,
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     harBruktEgenmelding = harBruktEgenmelding,
                     egenmeldingsperioder = egenmeldingsperioder,
                     harForsikring = harForsikring,
@@ -254,7 +254,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
             ArbeidssituasjonDTO.NAERINGSDRIVENDE -> {
                 NaringsdrivendeBrukerSvar(
                     erOpplysningeneRiktige = erOpplysningeneRiktige,
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     harBruktEgenmelding = harBruktEgenmelding,
                     egenmeldingsperioder = egenmeldingsperioder,
                     harForsikring = harForsikring,
@@ -264,7 +264,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
             ArbeidssituasjonDTO.JORDBRUKER -> {
                 JordbrukerBrukerSvar(
                     erOpplysningeneRiktige = erOpplysningeneRiktige,
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     uriktigeOpplysninger = uriktigeOpplysninger,
                     harBruktEgenmelding = harBruktEgenmelding,
                     egenmeldingsperioder = egenmeldingsperioder,
@@ -274,7 +274,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
             ArbeidssituasjonDTO.ARBEIDSLEDIG -> {
                 ArbeidsledigBrukerSvar(
                     erOpplysningeneRiktige = erOpplysningeneRiktige,
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     arbeidsledigFraOrgnummer = arbeidsgiverOrgnummer,
                     uriktigeOpplysninger = uriktigeOpplysninger,
                 )
@@ -282,7 +282,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
             ArbeidssituasjonDTO.PERMITTERT -> {
                 PermittertBrukerSvar(
                     erOpplysningeneRiktige = erOpplysningeneRiktige,
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     arbeidsledigFraOrgnummer = arbeidsgiverOrgnummer,
                     uriktigeOpplysninger = uriktigeOpplysninger,
                 )
@@ -290,7 +290,7 @@ class SykmeldingHendelseFraKafkaKonverterer(
             ArbeidssituasjonDTO.ANNET -> {
                 AnnetArbeidssituasjonBrukerSvar(
                     erOpplysningeneRiktige = erOpplysningeneRiktige,
-                    arbeidssituasjonSporsmal = arbeidssituasjon,
+                    arbeidssituasjon = arbeidssituasjon,
                     uriktigeOpplysninger = uriktigeOpplysninger,
                 )
             }

--- a/src/main/resources/db/migration/V31__hendelse_bruker_svar_type.sql
+++ b/src/main/resources/db/migration/V31__hendelse_bruker_svar_type.sql
@@ -1,0 +1,6 @@
+UPDATE SYKMELDINGHENDELSE
+SET bruker_svar = jsonb_build_object(
+                          'type', bruker_svar->'arbeidssituasjon',
+                          'arbeidssituasjon', bruker_svar->'arbeidssituasjonSporsmal'
+                  ) || (bruker_svar - 'arbeidssituasjon' - 'arbeidssituasjonSporsmal')
+WHERE bruker_svar IS NOT NULL;

--- a/src/test/kotlin/no/nav/helse/flex/api/SykmeldingStatusDtoKonvertererTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/api/SykmeldingStatusDtoKonvertererTest.kt
@@ -107,7 +107,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
                             sporsmaltekst = "Er opplysningene riktige?",
                             svar = true,
                         ),
-                    arbeidssituasjonSporsmal =
+                    arbeidssituasjon =
                         SporsmalSvar(
                             sporsmaltekst = "Hvilken arbeidssituasjon?",
                             svar = Arbeidssituasjon.ARBEIDSTAKER,
@@ -183,7 +183,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
             val brukerSvar =
                 ArbeidstakerBrukerSvar(
                     erOpplysningeneRiktige = lagSporsmalSvar(false),
-                    arbeidssituasjonSporsmal = lagSporsmalSvar(Arbeidssituasjon.ARBEIDSTAKER),
+                    arbeidssituasjon = lagSporsmalSvar(Arbeidssituasjon.ARBEIDSTAKER),
                     arbeidsgiverOrgnummer = lagSporsmalSvar("orgnr"),
                     riktigNarmesteLeder = lagSporsmalSvar(false),
                     harEgenmeldingsdager = lagSporsmalSvar(false),
@@ -218,7 +218,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
                             sporsmaltekst = "Er opplysningene riktige?",
                             svar = true,
                         ),
-                    arbeidssituasjonSporsmal =
+                    arbeidssituasjon =
                         SporsmalSvar(
                             sporsmaltekst = "Hvilken arbeidssituasjon?",
                             svar = Arbeidssituasjon.ARBEIDSLEDIG,
@@ -269,7 +269,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
             val brukerSvar =
                 ArbeidsledigBrukerSvar(
                     erOpplysningeneRiktige = lagSporsmalSvar(false),
-                    arbeidssituasjonSporsmal = lagSporsmalSvar(Arbeidssituasjon.ARBEIDSLEDIG),
+                    arbeidssituasjon = lagSporsmalSvar(Arbeidssituasjon.ARBEIDSLEDIG),
                 )
 
             val konvertertStatus: SykmeldingSporsmalSvarDto =
@@ -298,7 +298,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
                             sporsmaltekst = "Er opplysningene riktige?",
                             svar = true,
                         ),
-                    arbeidssituasjonSporsmal =
+                    arbeidssituasjon =
                         SporsmalSvar(
                             sporsmaltekst = "Hvilken arbeidssituasjon?",
                             svar = Arbeidssituasjon.PERMITTERT,
@@ -349,7 +349,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
             val brukerSvar =
                 PermittertBrukerSvar(
                     erOpplysningeneRiktige = lagSporsmalSvar(false),
-                    arbeidssituasjonSporsmal = lagSporsmalSvar(Arbeidssituasjon.PERMITTERT),
+                    arbeidssituasjon = lagSporsmalSvar(Arbeidssituasjon.PERMITTERT),
                 )
 
             val konvertertStatus: SykmeldingSporsmalSvarDto =
@@ -378,7 +378,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
                             sporsmaltekst = "Er opplysningene riktige?",
                             svar = true,
                         ),
-                    arbeidssituasjonSporsmal =
+                    arbeidssituasjon =
                         SporsmalSvar(
                             sporsmaltekst = "Hvilken arbeidssituasjon?",
                             svar = Arbeidssituasjon.FISKER,
@@ -503,7 +503,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
             val brukerSvar =
                 FiskerBrukerSvar(
                     erOpplysningeneRiktige = lagSporsmalSvar(false),
-                    arbeidssituasjonSporsmal = lagSporsmalSvar(Arbeidssituasjon.FISKER),
+                    arbeidssituasjon = lagSporsmalSvar(Arbeidssituasjon.FISKER),
                     arbeidsgiverOrgnummer = null,
                     riktigNarmesteLeder = lagSporsmalSvar(false),
                     harEgenmeldingsdager = lagSporsmalSvar(false),
@@ -546,7 +546,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
                             sporsmaltekst = "Er opplysningene riktige?",
                             svar = true,
                         ),
-                    arbeidssituasjonSporsmal =
+                    arbeidssituasjon =
                         SporsmalSvar(
                             sporsmaltekst = "Hvilken arbeidssituasjon?",
                             svar = Arbeidssituasjon.FRILANSER,
@@ -614,7 +614,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
             val brukerSvar =
                 FrilanserBrukerSvar(
                     erOpplysningeneRiktige = lagSporsmalSvar(false),
-                    arbeidssituasjonSporsmal = lagSporsmalSvar(Arbeidssituasjon.FRILANSER),
+                    arbeidssituasjon = lagSporsmalSvar(Arbeidssituasjon.FRILANSER),
                     harBruktEgenmelding = lagSporsmalSvar(false),
                     egenmeldingsperioder = null,
                     harForsikring = lagSporsmalSvar(false),
@@ -648,7 +648,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
                             sporsmaltekst = "Er opplysningene riktige?",
                             svar = true,
                         ),
-                    arbeidssituasjonSporsmal =
+                    arbeidssituasjon =
                         SporsmalSvar(
                             sporsmaltekst = "Hvilken arbeidssituasjon?",
                             svar = Arbeidssituasjon.JORDBRUKER,
@@ -716,7 +716,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
             val brukerSvar =
                 JordbrukerBrukerSvar(
                     erOpplysningeneRiktige = lagSporsmalSvar(false),
-                    arbeidssituasjonSporsmal = lagSporsmalSvar(Arbeidssituasjon.JORDBRUKER),
+                    arbeidssituasjon = lagSporsmalSvar(Arbeidssituasjon.JORDBRUKER),
                     harBruktEgenmelding = lagSporsmalSvar(false),
                     egenmeldingsperioder = null,
                     harForsikring = lagSporsmalSvar(false),
@@ -750,7 +750,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
                             sporsmaltekst = "Er opplysningene riktige?",
                             svar = true,
                         ),
-                    arbeidssituasjonSporsmal =
+                    arbeidssituasjon =
                         SporsmalSvar(
                             sporsmaltekst = "Hvilken arbeidssituasjon?",
                             svar = Arbeidssituasjon.NAERINGSDRIVENDE,
@@ -818,7 +818,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
             val brukerSvar =
                 NaringsdrivendeBrukerSvar(
                     erOpplysningeneRiktige = lagSporsmalSvar(false),
-                    arbeidssituasjonSporsmal = lagSporsmalSvar(Arbeidssituasjon.NAERINGSDRIVENDE),
+                    arbeidssituasjon = lagSporsmalSvar(Arbeidssituasjon.NAERINGSDRIVENDE),
                     harBruktEgenmelding = lagSporsmalSvar(false),
                     egenmeldingsperioder = null,
                     harForsikring = lagSporsmalSvar(false),
@@ -852,7 +852,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
                             sporsmaltekst = "Er opplysningene riktige?",
                             svar = true,
                         ),
-                    arbeidssituasjonSporsmal =
+                    arbeidssituasjon =
                         SporsmalSvar(
                             sporsmaltekst = "Hvilken arbeidssituasjon?",
                             svar = Arbeidssituasjon.ANNET,
@@ -896,7 +896,7 @@ class SykmeldingStatusDtoKonvertererTest : FakesTestOppsett() {
             val brukerSvar =
                 AnnetArbeidssituasjonBrukerSvar(
                     erOpplysningeneRiktige = lagSporsmalSvar(false),
-                    arbeidssituasjonSporsmal = lagSporsmalSvar(Arbeidssituasjon.ANNET),
+                    arbeidssituasjon = lagSporsmalSvar(Arbeidssituasjon.ANNET),
                     uriktigeOpplysninger = null,
                 )
 

--- a/src/test/kotlin/no/nav/helse/flex/sykmelding/domain/SykmeldingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/sykmelding/domain/SykmeldingRepositoryTest.kt
@@ -174,9 +174,9 @@ class SykmeldingRepositoryTest : IntegrasjonTestOppsett() {
         ).map { brukerSvar ->
             val caseId =
                 if (brukerSvar is FiskerBrukerSvar) {
-                    "${brukerSvar.arbeidssituasjon.name}-${brukerSvar.lottOgHyre.svar}"
+                    "${brukerSvar.type.name}-${brukerSvar.lottOgHyre.svar}"
                 } else {
-                    brukerSvar.arbeidssituasjon.name
+                    brukerSvar.type.name
                 }
 
             DynamicTest.dynamicTest("burde lagre hendelse med brukerSvar for $caseId") {

--- a/src/test/kotlin/no/nav/helse/flex/testdata/BrukerSvarTestData.kt
+++ b/src/test/kotlin/no/nav/helse/flex/testdata/BrukerSvarTestData.kt
@@ -4,7 +4,7 @@ import no.nav.helse.flex.sykmelding.application.*
 import java.time.LocalDate
 
 fun lagArbeidstakerBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.ARBEIDSTAKER),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.ARBEIDSTAKER),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     arbeidsgiverOrgnummer: SporsmalSvar<String> = lagSporsmalSvar("test-orgnummer"),
     riktigNarmesteLeder: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
@@ -13,7 +13,7 @@ fun lagArbeidstakerBrukerSvar(
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): ArbeidstakerBrukerSvar =
     ArbeidstakerBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         arbeidsgiverOrgnummer = arbeidsgiverOrgnummer,
         riktigNarmesteLeder = riktigNarmesteLeder,
@@ -23,33 +23,33 @@ fun lagArbeidstakerBrukerSvar(
     )
 
 fun lagArbeidsledigBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.ARBEIDSLEDIG),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.ARBEIDSLEDIG),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     arbeidsledigFraOrgnummer: SporsmalSvar<String>? = null,
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): ArbeidsledigBrukerSvar =
     ArbeidsledigBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         arbeidsledigFraOrgnummer = arbeidsledigFraOrgnummer,
         uriktigeOpplysninger = uriktigeOpplysninger,
     )
 
 fun lagPermittertBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.PERMITTERT),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.PERMITTERT),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     arbeidsledigFraOrgnummer: SporsmalSvar<String>? = null,
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): PermittertBrukerSvar =
     PermittertBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         arbeidsledigFraOrgnummer = arbeidsledigFraOrgnummer,
         uriktigeOpplysninger = uriktigeOpplysninger,
     )
 
 fun lagFiskerHyreBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.FISKER),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.FISKER),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     lottOgHyre: SporsmalSvar<FiskerLottOgHyre> = lagSporsmalSvar(FiskerLottOgHyre.HYRE),
     blad: SporsmalSvar<FiskerBlad> = lagSporsmalSvar(FiskerBlad.A),
@@ -60,7 +60,7 @@ fun lagFiskerHyreBrukerSvar(
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): FiskerBrukerSvar =
     FiskerBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         lottOgHyre = lottOgHyre,
         blad = blad,
@@ -72,7 +72,7 @@ fun lagFiskerHyreBrukerSvar(
     )
 
 fun lagFiskerLottBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.FISKER),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.FISKER),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     lottOgHyre: SporsmalSvar<FiskerLottOgHyre> = lagSporsmalSvar(FiskerLottOgHyre.LOTT),
     blad: SporsmalSvar<FiskerBlad> = lagSporsmalSvar(FiskerBlad.A),
@@ -82,7 +82,7 @@ fun lagFiskerLottBrukerSvar(
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): FiskerBrukerSvar =
     FiskerBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         lottOgHyre = lottOgHyre,
         blad = blad,
@@ -93,7 +93,7 @@ fun lagFiskerLottBrukerSvar(
     )
 
 fun lagFrilanserBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.FRILANSER),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.FRILANSER),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     harBruktEgenmelding: SporsmalSvar<Boolean> = lagSporsmalSvar(false),
     egenmeldingsperioder: SporsmalSvar<List<Egenmeldingsperiode>>? = null,
@@ -101,7 +101,7 @@ fun lagFrilanserBrukerSvar(
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): FrilanserBrukerSvar =
     FrilanserBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         harBruktEgenmelding = harBruktEgenmelding,
         egenmeldingsperioder = egenmeldingsperioder,
@@ -110,7 +110,7 @@ fun lagFrilanserBrukerSvar(
     )
 
 fun lagJordbrukerBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.JORDBRUKER),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.JORDBRUKER),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     harBruktEgenmelding: SporsmalSvar<Boolean> = lagSporsmalSvar(false),
     egenmeldingsperioder: SporsmalSvar<List<Egenmeldingsperiode>>? = null,
@@ -118,7 +118,7 @@ fun lagJordbrukerBrukerSvar(
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): JordbrukerBrukerSvar =
     JordbrukerBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         harBruktEgenmelding = harBruktEgenmelding,
         egenmeldingsperioder = egenmeldingsperioder,
@@ -127,7 +127,7 @@ fun lagJordbrukerBrukerSvar(
     )
 
 fun lagNaringsdrivendeBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.NAERINGSDRIVENDE),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.NAERINGSDRIVENDE),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     harBruktEgenmelding: SporsmalSvar<Boolean> = lagSporsmalSvar(false),
     egenmeldingsperioder: SporsmalSvar<List<Egenmeldingsperiode>>? = null,
@@ -135,7 +135,7 @@ fun lagNaringsdrivendeBrukerSvar(
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): NaringsdrivendeBrukerSvar =
     NaringsdrivendeBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         harBruktEgenmelding = harBruktEgenmelding,
         egenmeldingsperioder = egenmeldingsperioder,
@@ -144,12 +144,12 @@ fun lagNaringsdrivendeBrukerSvar(
     )
 
 fun lagAnnetArbeidssituasjonBrukerSvar(
-    arbeidssituasjonSporsmal: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.ANNET),
+    arbeidssituasjon: SporsmalSvar<Arbeidssituasjon> = lagSporsmalSvar(Arbeidssituasjon.ANNET),
     erOpplysningeneRiktige: SporsmalSvar<Boolean> = lagSporsmalSvar(true),
     uriktigeOpplysninger: SporsmalSvar<List<UriktigeOpplysning>>? = null,
 ): AnnetArbeidssituasjonBrukerSvar =
     AnnetArbeidssituasjonBrukerSvar(
-        arbeidssituasjonSporsmal = arbeidssituasjonSporsmal,
+        arbeidssituasjon = arbeidssituasjon,
         erOpplysningeneRiktige = erOpplysningeneRiktige,
         uriktigeOpplysninger = uriktigeOpplysninger,
     )

--- a/src/test/kotlin/no/nav/helse/flex/tsmsykmeldingstatus/SykmeldingHendelseFraKafkaKonvertererTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/tsmsykmeldingstatus/SykmeldingHendelseFraKafkaKonvertererTest.kt
@@ -106,7 +106,7 @@ class SykmeldingHendelseFraKafkaKonvertererTest : FakesTestOppsett() {
             )
         val hendelse = sykmeldingHendelseFraKafkaKonverterer.konverterSykmeldingHendelseFraKafkaDTO(status)
         hendelse.brukerSvar.shouldNotBeNull().run {
-            arbeidssituasjonSporsmal.svar `should be equal to` Arbeidssituasjon.ARBEIDSTAKER
+            arbeidssituasjon.svar `should be equal to` Arbeidssituasjon.ARBEIDSTAKER
         }
     }
 
@@ -144,7 +144,7 @@ class SykmeldingHendelseFraKafkaKonvertererTest : FakesTestOppsett() {
         val konvertert = sykmeldingHendelseFraKafkaKonverterer.konverterBrukerSvarKafkaDtoTilBrukerSvar(brukerSvarKafkaDTO)
         konvertert.uriktigeOpplysninger?.svar `should be equal to` listOf(UriktigeOpplysning.PERIODE)
         konvertert.erOpplysningeneRiktige.svar `should be equal to` true
-        konvertert.arbeidssituasjonSporsmal.svar.name `should be equal to` arbeidssituasjonDTO.name
+        konvertert.arbeidssituasjon.svar.name `should be equal to` arbeidssituasjonDTO.name
 
         when (arbeidssituasjonDTO) {
             ArbeidssituasjonDTO.ARBEIDSTAKER -> {


### PR DESCRIPTION
Hva tenker dere om denne løsningen for å håndtere inkonsistente brukersvar formater?

På grunn av uforutset inkonsistens i historiske sykmeldingstatuser, ser vi det som mest hensiktsmessig å innføre en BrukerSvar type (UtdatertFormatBrukerSvar) som er mer fleksibel enn appen krever ved innsending (bekreftelse) av nye sykmeldigner.

Dette lar oss også enkelt filterer bort BrukerSvar som ikke skal vises til brukere, istedetfor å filtrere bort brukerSvar eldre enn en gitt dato.

I tillegg gjør vi en migrasjon av BrukerSvar felter:
- `arbeidssituasjon` -> `type`. Dette er allerede et felt som kun brukes for (de)serialisering av type til riktig klasse
-  `arbeidssituasjonSporsmal` -> `arbeidssituasjon`. Dette feltet het egentlig arbeidssituasjon, men ble omdøpt pga feltet beskrevet i punktet over