### PR TITLE
Endre datatyper for stillingsprosent og permisjonsprosent til Double i AaregDomene og tilpasse tester

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/clients/aareg/AaregDomene.kt
+++ b/src/main/kotlin/no/nav/helse/flex/clients/aareg/AaregDomene.kt
@@ -21,9 +21,9 @@ data class ArbeidsforholdOversikt(
     val startdato: LocalDate,
     val sluttdato: LocalDate? = null,
     val yrke: Kodeverksentitet,
-    val avtaltStillingsprosent: Int,
-    val permisjonsprosent: Int? = null,
-    val permitteringsprosent: Int? = null,
+    val avtaltStillingsprosent: Double,
+    val permisjonsprosent: Double? = null,
+    val permitteringsprosent: Double? = null,
 )
 
 data class Kodeverksentitet(

--- a/src/test/kotlin/no/nav/helse/flex/arbeidsforhold/innhenting/EksternArbeidsforholdHenterTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/arbeidsforhold/innhenting/EksternArbeidsforholdHenterTest.kt
@@ -282,8 +282,8 @@ class EksternArbeidsforholdHenterTest {
                     kode = "1231119",
                     beskrivelse = "KONTORLEDER",
                 ),
-            avtaltStillingsprosent = 100,
-            permisjonsprosent = 50,
-            permitteringsprosent = 50,
+            avtaltStillingsprosent = 100.0,
+            permisjonsprosent = 50.0,
+            permitteringsprosent = 50.0,
         )
 }


### PR DESCRIPTION
Det siste døgnet har vi fått en del feil fra kall til /api/v2/arbeidstaker/arbeidsforholdoversikt . Ser avtaltStillingsprosent skal være double
```
Exception: JSON parse error: Numeric value (9.7504993E9) out of range of int (-2147483648 - 2147483647)
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.readJavaType(AbstractJackson2HttpMessageConverter.java:408)
	at org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter.read(AbstractJackson2HttpMessageConverter.java:356)
	at org.springframework.web.client.DefaultRestClient.readWithMessageConverters(DefaultRestClient.java:229)
	... 38 common frames omitted
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Numeric value (9.7504993E9) out of range of int (-2147483648 - 2147483647)
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1407] (through reference chain: no.nav.helse.flex.clients.aareg.ArbeidsforholdoversiktResponse["arbeidsforholdoversikter"]->java.util.ArrayList[1]->no.nav.helse.flex.clients.aareg.ArbeidsforholdOversikt["avtaltStillingsprosent"])
```