### PR TITLE
forbedre sykmeldingstatus sync logging

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/listeners/SykmeldingStatusListener.kt
+++ b/src/main/kotlin/no/nav/helse/flex/listeners/SykmeldingStatusListener.kt
@@ -40,7 +40,7 @@ class SykmeldingStatusListener(
     }
 
     internal fun prosesserKafkaRecord(cr: ConsumerRecord<String, String>) {
-        log.info("Mottatt status for sykmelding: ${cr.key()}")
+        log.info("Mottatt status for sykmelding '${cr.key()}' på kafka topic '${cr.topic()}'")
         val status: SykmeldingStatusKafkaMessageDTO =
             try {
                 objectMapper.readValue(cr.value())

--- a/src/main/kotlin/no/nav/helse/flex/tsmsykmeldingstatus/SykmeldingStatusHandterer.kt
+++ b/src/main/kotlin/no/nav/helse/flex/tsmsykmeldingstatus/SykmeldingStatusHandterer.kt
@@ -48,13 +48,13 @@ class SykmeldingStatusHandterer(
         } else {
             return when (val statusEvent = status.event.statusEvent) {
                 StatusEventKafkaDTO.SLETTET -> {
-                    log.debug(
+                    log.info(
                         "Ignorerer status $statusEvent for sykmelding '$sykmeldingId'. Sykmelding slettes kun ved tombstone på sykmeldinger topic",
                     )
                     true
                 }
                 StatusEventKafkaDTO.APEN -> {
-                    log.debug("Ignorerer status $statusEvent for sykmelding '$sykmeldingId'")
+                    log.info("Ignorerer status $statusEvent for sykmelding '$sykmeldingId'")
                     true
                 }
                 else -> {
@@ -131,7 +131,7 @@ class SykmeldingStatusHandterer(
             validerStatusForSykmelding(sykmelding, status)
         }
         sykmeldingRepository.save(sykmelding.leggTilHendelse(hendelse))
-        log.info("Hendelse ${hendelse.status} for sykmelding $sykmeldingId lagret")
+        log.info("Lagret hendelse ${hendelse.status} for sykmelding $sykmeldingId")
 
         return true
     }


### PR DESCRIPTION
Gitt nylig sykmelding bug (https://nav-it.slack.com/archives/CMA3XV997/p1754300633066839) var det ikke så lett å følge hvilke statuser som har blitt skippet og hvilke som er håndtert hos oss.

Dagens log ser slik ut:
<img width="1849" height="277" alt="image" src="https://github.com/user-attachments/assets/88b8623e-30de-407f-a45d-7f22638af8d5" />
