### PR TITLE
Øk antall tråder og max connections http connections

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/RestClientConfig.kt
@@ -144,8 +144,8 @@ class RestClientConfig {
         val connectionManager =
             PoolingHttpClientConnectionManagerBuilder
                 .create()
-                .setMaxConnTotal(40)
-                .setMaxConnPerRoute(20)
+                .setMaxConnTotal(100)
+                .setMaxConnPerRoute(50)
                 .setDefaultConnectionConfig(connectionConfig)
                 .build()
 

--- a/src/main/kotlin/no/nav/helse/flex/config/SchedulerConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/SchedulerConfig.kt
@@ -24,6 +24,6 @@ class SchedulerConfig {
     @Bean
     fun aaregHendelserKafkaTaskExecutor(): ConcurrentTaskExecutor =
         ConcurrentTaskExecutor(
-            Executors.newFixedThreadPool(30),
+            Executors.newFixedThreadPool(50),
         )
 }


### PR DESCRIPTION
Er mye volum nå fordi Aareg hadde backlog med hendelser etter kafkaproblemer i helga, så da kan vi prøve å øke connections og tråder litt til for å se hvordan det påvirker ytelsen.