### PR TITLE
feat: implementer SykepengesoknadBackendClient med TokenX og harSoknad-kall

### DIFF
--- a/nais/app/dev.yaml
+++ b/nais/app/dev.yaml
@@ -27,4 +27,6 @@ env:
   AAREG_AAD_CLIENT_ID: dev-fss.arbeidsforhold.aareg-services-nais
   FLEX_SYKETILFELLE_URL: http://flex-syketilfelle
   FLEX_SYKETILFELLE_TOKENX_CLIENT_ID: dev-gcp:flex:flex-syketilfelle
+  SYKEPENGESOKNAD_BACKEND_URL: http://sykepengesoknad-backend
+  SYKEPENGESOKNAD_BACKEND_TOKENX_CLIENT_ID: dev-gcp:flex:sykepengesoknad-backend
   FLEX_GROUP_ID: "34094735-b8f7-4bef-9136-47de2307541a" #0000-GA-TEMA_SYK

--- a/nais/app/naiserator.yaml
+++ b/nais/app/naiserator.yaml
@@ -52,6 +52,7 @@ spec:
     outbound:
       rules:
         - application: flex-syketilfelle
+        - application: sykepengesoknad-backend
         - application: logging
           namespace: nais-system
       external:

--- a/nais/app/prod.yaml
+++ b/nais/app/prod.yaml
@@ -29,4 +29,6 @@ env:
   AAREG_AAD_CLIENT_ID: prod-fss.arbeidsforhold.aareg-services-nais
   FLEX_SYKETILFELLE_URL: http://flex-syketilfelle
   FLEX_SYKETILFELLE_TOKENX_CLIENT_ID: prod-gcp:flex:flex-syketilfelle
+  SYKEPENGESOKNAD_BACKEND_URL: http://sykepengesoknad-backend
+  SYKEPENGESOKNAD_BACKEND_TOKENX_CLIENT_ID: prod-gcp:flex:sykepengesoknad-backend
   FLEX_GROUP_ID: "5206a646-a99e-4cd5-90e4-758cf7948cc8"

--- a/src/main/kotlin/no/nav/helse/flex/config/RestClientConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/RestClientConfig.kt
@@ -121,6 +121,27 @@ class RestClientConfig {
     }
 
     @Bean
+    fun sykepengesoknadBackendRestClient(
+        @Value("\${SYKEPENGESOKNAD_BACKEND_URL}") url: String,
+        oAuth2AccessTokenService: OAuth2AccessTokenService,
+        clientConfigurationProperties: ClientConfigurationProperties,
+        requestFactory: HttpComponentsClientHttpRequestFactory,
+        observationRegistry: ObservationRegistry,
+    ): RestClient {
+        val clientProperties =
+            clientConfigurationProperties.registration["sykepengesoknad-backend-tokenx"]
+                ?: throw RuntimeException("Fant ikke config for sykepengesoknad-backend-tokenx.")
+
+        return RestClient
+            .builder()
+            .baseUrl(url)
+            .requestFactory(requestFactory)
+            .observationRegistry(observationRegistry)
+            .requestInterceptor(BearerTokenInterceptor(oAuth2AccessTokenService, clientProperties))
+            .build()
+    }
+
+    @Bean
     fun texasRestClient(
         @Value($$"${NAIS_TOKEN_INTROSPECTION_ENDPOINT}") url: String,
         requestFactory: HttpComponentsClientHttpRequestFactory,

--- a/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendClient.kt
@@ -1,0 +1,5 @@
+package no.nav.helse.flex.gateways.sykepengesoknadbackend
+
+interface SykepengesoknadBackendClient {
+    fun harSoknad(sykmeldingUuid: String): Boolean
+}

--- a/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
@@ -13,7 +13,7 @@ class SykepengesoknadBackendEksternClient(
 ) : SykepengesoknadBackendClient {
     val log = logger()
 
-    @Retryable
+    @Retryable(exclude = [SykepengesoknadBackendClientException::class])
     override fun harSoknad(sykmeldingUuid: String): Boolean {
         val response =
             sykepengesoknadBackendRestClient
@@ -22,9 +22,21 @@ class SykepengesoknadBackendEksternClient(
                     uriBuilder.path("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad").build()
                 }.retrieve()
                 .onStatus(HttpStatusCode::isError) { _, httpResponse ->
-                    throw RuntimeException(
-                        "Kall til harSoknad feilet med HTTP-${httpResponse.statusCode.value()} for sykmelding $sykmeldingUuid",
-                    ).also {
+                    val exception =
+                        when {
+                            httpResponse.statusCode.is4xxClientError -> {
+                                SykepengesoknadBackendClientException(
+                                    "Kall til harSoknad feilet med HTTP-${httpResponse.statusCode.value()} for sykmelding $sykmeldingUuid",
+                                )
+                            }
+                            else -> {
+                                SykepengesoknadBackendServerException(
+                                    "Kall til harSoknad feilet med HTTP-${httpResponse.statusCode.value()} for sykmelding $sykmeldingUuid",
+                                )
+                            }
+                        }
+
+                    throw exception.also {
                         log.error(it.message)
                     }
                 }.toEntity<HarSoknadResponse>()
@@ -37,3 +49,11 @@ class SykepengesoknadBackendEksternClient(
 data class HarSoknadResponse(
     val harSoknad: Boolean,
 )
+
+private class SykepengesoknadBackendClientException(
+    message: String,
+) : RuntimeException(message)
+
+private class SykepengesoknadBackendServerException(
+    message: String,
+) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
@@ -20,16 +20,14 @@ class SykepengesoknadBackendEksternClient(
                 .get()
                 .uri { uriBuilder ->
                     uriBuilder.path("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad").build()
-                }
-                .retrieve()
+                }.retrieve()
                 .onStatus(HttpStatusCode::isError) { _, httpResponse ->
                     throw RuntimeException(
                         "Kall til harSoknad feilet med HTTP-${httpResponse.statusCode.value()} for sykmelding $sykmeldingUuid",
                     ).also {
                         log.error(it.message)
                     }
-                }
-                .toEntity<HarSoknadResponse>()
+                }.toEntity<HarSoknadResponse>()
 
         return response.body?.harSoknad
             ?: throw RuntimeException("harSoknad response inneholdt ikke data for sykmelding $sykmeldingUuid")

--- a/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
@@ -1,0 +1,42 @@
+package no.nav.helse.flex.gateways.sykepengesoknadbackend
+
+import no.nav.helse.flex.utils.logger
+import org.springframework.http.HttpStatusCode
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.toEntity
+
+@Component
+class SykepengesoknadBackendEksternClient(
+    private val sykepengesoknadBackendRestClient: RestClient,
+) : SykepengesoknadBackendClient {
+    val log = logger()
+
+    @Retryable
+    override fun harSoknad(sykmeldingUuid: String): Boolean {
+        val response =
+            sykepengesoknadBackendRestClient
+                .get()
+                .uri { uriBuilder ->
+                    uriBuilder.path("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad").build()
+                }
+                .retrieve()
+                .onStatus(HttpStatusCode::is4xxClientError) { _, httpResponse ->
+                    when (httpResponse.statusCode.value()) {
+                        401 -> log.warn("Ugyldig token ved kall til harSoknad for sykmelding $sykmeldingUuid")
+                        403 -> log.warn("Søknaden tilhører annen bruker ved kall til harSoknad for sykmelding $sykmeldingUuid")
+                        else -> throw RuntimeException(
+                            "Uventet 4xx-feil (${httpResponse.statusCode.value()}) ved kall til harSoknad for sykmelding $sykmeldingUuid",
+                        )
+                    }
+                }
+                .toEntity<HarSoknadResponse>()
+
+        return response.body?.harSoknad ?: false
+    }
+}
+
+data class HarSoknadResponse(
+    val harSoknad: Boolean,
+)

--- a/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
@@ -22,18 +22,17 @@ class SykepengesoknadBackendEksternClient(
                     uriBuilder.path("/api/v2/soknader/sykmelding/$sykmeldingUuid/harSoknad").build()
                 }
                 .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError) { _, httpResponse ->
-                    when (httpResponse.statusCode.value()) {
-                        401 -> log.warn("Ugyldig token ved kall til harSoknad for sykmelding $sykmeldingUuid")
-                        403 -> log.warn("Søknaden tilhører annen bruker ved kall til harSoknad for sykmelding $sykmeldingUuid")
-                        else -> throw RuntimeException(
-                            "Uventet 4xx-feil (${httpResponse.statusCode.value()}) ved kall til harSoknad for sykmelding $sykmeldingUuid",
-                        )
+                .onStatus(HttpStatusCode::isError) { _, httpResponse ->
+                    throw RuntimeException(
+                        "Kall til harSoknad feilet med HTTP-${httpResponse.statusCode.value()} for sykmelding $sykmeldingUuid",
+                    ).also {
+                        log.error(it.message)
                     }
                 }
                 .toEntity<HarSoknadResponse>()
 
-        return response.body?.harSoknad ?: false
+        return response.body?.harSoknad
+            ?: throw RuntimeException("harSoknad response inneholdt ikke data for sykmelding $sykmeldingUuid")
     }
 }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,6 +77,15 @@ no.nav.security.jwt:
           client-auth-method: private_key_jwt
         token-exchange:
           audience: ${FLEX_SYKETILFELLE_TOKENX_CLIENT_ID}
+      sykepengesoknad-backend-tokenx:
+        token-endpoint-url: ${TOKEN_X_TOKEN_ENDPOINT}
+        grant-type: urn:ietf:params:oauth:grant-type:token-exchange
+        authentication:
+          client-id: ${TOKEN_X_CLIENT_ID}
+          client-jwk: ${TOKEN_X_PRIVATE_JWK}
+          client-auth-method: private_key_jwt
+        token-exchange:
+          audience: ${SYKEPENGESOKNAD_BACKEND_TOKENX_CLIENT_ID}
 
 pdl.api.url: ${PDL_BASE_URL}
 elector.get_url: ${ELECTOR_GET_URL}

--- a/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
@@ -1,0 +1,96 @@
+package no.nav.helse.flex.gateways
+
+import no.nav.helse.flex.gateways.sykepengesoknadbackend.HarSoknadResponse
+import no.nav.helse.flex.gateways.sykepengesoknadbackend.SykepengesoknadBackendClient
+import no.nav.helse.flex.gateways.sykepengesoknadbackend.SykepengesoknadBackendEksternClient
+import no.nav.helse.flex.testconfig.RestClientOppsett
+import no.nav.helse.flex.testconfig.defaultSykepengesoknadBackendDispatcher
+import no.nav.helse.flex.testconfig.simpleDispatcher
+import no.nav.helse.flex.utils.serialisertTilString
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be false`
+import org.amshove.kluent.`should be true`
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+
+@RestClientOppsett
+@Import(SykepengesoknadBackendEksternClient::class)
+class SykepengesoknadBackendClientTest {
+    @Autowired
+    lateinit var sykepengesoknadBackendMockWebServer: MockWebServer
+
+    @Autowired
+    lateinit var sykepengesoknadBackendEksternClient: SykepengesoknadBackendClient
+
+    @AfterEach
+    fun afterEach() {
+        sykepengesoknadBackendMockWebServer.dispatcher = defaultSykepengesoknadBackendDispatcher
+    }
+
+    @Test
+    fun `burde returnere true når søknad finnes`() {
+        sykepengesoknadBackendMockWebServer.dispatcher =
+            simpleDispatcher {
+                MockResponse()
+                    .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
+                    .addHeader("Content-Type", "application/json")
+            }
+        val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+        resultat.`should be true`()
+    }
+
+    @Test
+    fun `burde returnere false når søknad ikke finnes`() {
+        sykepengesoknadBackendMockWebServer.dispatcher =
+            simpleDispatcher {
+                MockResponse()
+                    .setBody(HarSoknadResponse(harSoknad = false).serialisertTilString())
+                    .addHeader("Content-Type", "application/json")
+            }
+        val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+        resultat.`should be false`()
+    }
+
+    @Test
+    fun `burde returnere false ved 401`() {
+        sykepengesoknadBackendMockWebServer.dispatcher =
+            simpleDispatcher {
+                MockResponse()
+                    .setResponseCode(HttpStatus.UNAUTHORIZED.value())
+                    .addHeader("Content-Type", "application/json")
+            }
+        val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+        resultat.`should be false`()
+    }
+
+    @Test
+    fun `burde returnere false ved 403`() {
+        sykepengesoknadBackendMockWebServer.dispatcher =
+            simpleDispatcher {
+                MockResponse()
+                    .setResponseCode(HttpStatus.FORBIDDEN.value())
+                    .addHeader("Content-Type", "application/json")
+            }
+        val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+        resultat.`should be false`()
+    }
+
+    @Test
+    fun `burde sende riktig path`() {
+        sykepengesoknadBackendMockWebServer.dispatcher =
+            simpleDispatcher {
+                MockResponse()
+                    .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
+                    .addHeader("Content-Type", "application/json")
+            }
+        sykepengesoknadBackendEksternClient.harSoknad("min-sykmelding-id")
+
+        val request = sykepengesoknadBackendMockWebServer.takeRequest()
+        request.path `should be equal to` "/api/v2/soknader/sykmelding/min-sykmelding-id/harSoknad"
+    }
+}

--- a/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
@@ -10,11 +10,7 @@ import no.nav.helse.flex.utils.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
-import org.amshove.kluent.invoking
-import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should be false`
-import org.amshove.kluent.`should be true`
-import org.amshove.kluent.`should throw`
+import org.amshove.kluent.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -112,5 +108,22 @@ class SykepengesoknadBackendClientTest {
 
         val request = recordedRequest!!
         request.path `should be equal to` "/api/v2/soknader/sykmelding/min-sykmelding-id/harSoknad"
+    }
+
+    @Test
+    fun `burde sende bearer token i authorization header`() {
+        var recordedRequest: RecordedRequest? = null
+        sykepengesoknadBackendMockWebServer.dispatcher =
+            simpleDispatcher { request ->
+                recordedRequest = request
+                MockResponse()
+                    .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
+                    .addHeader("Content-Type", "application/json")
+            }
+
+        sykepengesoknadBackendEksternClient.harSoknad("test-id")
+
+        val request = recordedRequest!!
+        request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
@@ -10,10 +10,10 @@ import no.nav.helse.flex.utils.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import org.amshove.kluent.invoking
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be false`
 import org.amshove.kluent.`should be true`
-import org.amshove.kluent.invoking
 import org.amshove.kluent.`should throw`
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
@@ -13,6 +13,8 @@ import okhttp3.mockwebserver.RecordedRequest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be false`
 import org.amshove.kluent.`should be true`
+import org.amshove.kluent.invoking
+import org.amshove.kluent.`should throw`
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -58,27 +60,41 @@ class SykepengesoknadBackendClientTest {
     }
 
     @Test
-    fun `burde returnere false ved 401`() {
+    fun `burde kaste feil ved 401`() {
         sykepengesoknadBackendMockWebServer.dispatcher =
             simpleDispatcher {
                 MockResponse()
                     .setResponseCode(HttpStatus.UNAUTHORIZED.value())
                     .addHeader("Content-Type", "application/json")
             }
-        val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
-        resultat.`should be false`()
+        invoking {
+            sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+        } `should throw` RuntimeException::class
     }
 
     @Test
-    fun `burde returnere false ved 403`() {
+    fun `burde kaste feil ved 403`() {
         sykepengesoknadBackendMockWebServer.dispatcher =
             simpleDispatcher {
                 MockResponse()
                     .setResponseCode(HttpStatus.FORBIDDEN.value())
                     .addHeader("Content-Type", "application/json")
             }
-        val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
-        resultat.`should be false`()
+        invoking {
+            sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+        } `should throw` RuntimeException::class
+    }
+
+    @Test
+    fun `burde kaste feil ved tom body`() {
+        sykepengesoknadBackendMockWebServer.dispatcher =
+            simpleDispatcher {
+                MockResponse()
+                    .addHeader("Content-Type", "application/json")
+            }
+        invoking {
+            sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+        } `should throw` RuntimeException::class
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
+import java.util.concurrent.TimeUnit
 
 @RestClientOppsett
 @Import(SykepengesoknadBackendEksternClient::class)
@@ -88,6 +89,13 @@ class SykepengesoknadBackendClientTest {
                     .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
                     .addHeader("Content-Type", "application/json")
             }
+
+        // Tøm eventuelle tidligere forespørsler som ligger i køen, slik at
+        // takeRequest() returnerer requesten fra dette testkallet.
+        while (sykepengesoknadBackendMockWebServer.takeRequest(10, TimeUnit.MILLISECONDS) != null) {
+            // discard
+        }
+
         sykepengesoknadBackendEksternClient.harSoknad("min-sykmelding-id")
 
         val request = sykepengesoknadBackendMockWebServer.takeRequest()

--- a/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
@@ -9,6 +9,7 @@ import no.nav.helse.flex.testconfig.simpleDispatcher
 import no.nav.helse.flex.utils.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be false`
 import org.amshove.kluent.`should be true`
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
-import java.util.concurrent.TimeUnit
 
 @RestClientOppsett
 @Import(SykepengesoknadBackendEksternClient::class)
@@ -83,22 +83,18 @@ class SykepengesoknadBackendClientTest {
 
     @Test
     fun `burde sende riktig path`() {
+        var recordedRequest: RecordedRequest? = null
         sykepengesoknadBackendMockWebServer.dispatcher =
-            simpleDispatcher {
+            simpleDispatcher { request ->
+                recordedRequest = request
                 MockResponse()
                     .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
                     .addHeader("Content-Type", "application/json")
             }
 
-        // Tøm eventuelle tidligere forespørsler som ligger i køen, slik at
-        // takeRequest() returnerer requesten fra dette testkallet.
-        while (sykepengesoknadBackendMockWebServer.takeRequest(10, TimeUnit.MILLISECONDS) != null) {
-            // discard
-        }
-
         sykepengesoknadBackendEksternClient.harSoknad("min-sykmelding-id")
 
-        val request = sykepengesoknadBackendMockWebServer.takeRequest()
+        val request = recordedRequest!!
         request.path `should be equal to` "/api/v2/soknader/sykmelding/min-sykmelding-id/harSoknad"
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/testconfig/FakesTestConfig.kt
+++ b/src/test/kotlin/no/nav/helse/flex/testconfig/FakesTestConfig.kt
@@ -55,6 +55,9 @@ class FakesTestConfig {
     fun syketilfelleClient(): SyketilfelleClientFake = SyketilfelleClientFake()
 
     @Bean
+    fun sykepengesoknadBackendClient(): SykepengesoknadBackendClientFake = SykepengesoknadBackendClientFake()
+
+    @Bean
     fun sykmeldingBrukernotifikasjonProducer(): SykmeldingBrukernotifikasjonProducerFake = SykmeldingBrukernotifikasjonProducerFake()
 
     @Bean

--- a/src/test/kotlin/no/nav/helse/flex/testconfig/MockWebServereConfig.kt
+++ b/src/test/kotlin/no/nav/helse/flex/testconfig/MockWebServereConfig.kt
@@ -8,6 +8,7 @@ import no.nav.helse.flex.gateways.pdl.GraphQlRequest
 import no.nav.helse.flex.gateways.pdl.lagGetPersonResponseData
 import no.nav.helse.flex.gateways.pdl.lagGraphQlResponse
 import no.nav.helse.flex.gateways.pdl.lagHentIdenterResponseData
+import no.nav.helse.flex.gateways.sykepengesoknadbackend.HarSoknadResponse
 import no.nav.helse.flex.gateways.syketilfelle.ErUtenforVentetidResponse
 import no.nav.helse.flex.utils.logger
 import no.nav.helse.flex.utils.objectMapper
@@ -74,6 +75,13 @@ val defaultPdlDispatcher =
         }
     }
 
+val defaultSykepengesoknadBackendDispatcher =
+    simpleDispatcher {
+        MockResponse()
+            .setHeader("Content-Type", "application/json")
+            .setBody(HarSoknadResponse(harSoknad = false).serialisertTilString())
+    }
+
 @TestConfiguration
 class MockWebServereConfig {
     @Bean
@@ -90,6 +98,9 @@ class MockWebServereConfig {
 
     @Bean
     fun syketilfelleMockWebServer() = syketilfelleMockWebServer
+
+    @Bean
+    fun sykepengesoknadBackendMockWebServer() = sykepengesoknadBackendMockWebServer
 
     companion object {
         val logger = logger()
@@ -118,11 +129,17 @@ class MockWebServereConfig {
                 dispatcher = defaultSyketilfelleDispatcher
             }
 
+        val sykepengesoknadBackendMockWebServer =
+            MockWebServer().apply {
+                dispatcher = defaultSykepengesoknadBackendDispatcher
+            }
+
         init {
             System.setProperty("PDL_BASE_URL", "http://localhost:${pdlMockWebServer.port}")
             System.setProperty("AAREG_URL", "http://localhost:${aaregMockWebServer.port}")
             System.setProperty("EREG_URL", "http://localhost:${eregMockWebServer.port}")
             System.setProperty("FLEX_SYKETILFELLE_URL", "http://localhost:${syketilfelleMockWebServer.port}")
+            System.setProperty("SYKEPENGESOKNAD_BACKEND_URL", "http://localhost:${sykepengesoknadBackendMockWebServer.port}")
         }
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/testconfig/fakes/SykepengesoknadBackendClientFake.kt
+++ b/src/test/kotlin/no/nav/helse/flex/testconfig/fakes/SykepengesoknadBackendClientFake.kt
@@ -1,0 +1,17 @@
+package no.nav.helse.flex.testconfig.fakes
+
+import no.nav.helse.flex.gateways.sykepengesoknadbackend.SykepengesoknadBackendClient
+
+class SykepengesoknadBackendClientFake : SykepengesoknadBackendClient {
+    private var harSoknadResponse = false
+
+    override fun harSoknad(sykmeldingUuid: String): Boolean = harSoknadResponse
+
+    fun setHarSoknad(harSoknad: Boolean) {
+        harSoknadResponse = harSoknad
+    }
+
+    fun reset() {
+        harSoknadResponse = false
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -71,6 +71,14 @@ no.nav.security.jwt:
           client-id: client-id
           client-secret: secretzz
           client-auth-method: client_secret_basic
+      sykepengesoknad-backend-tokenx:
+        token-endpoint-url: http://localhost:${mock-oauth2-server.port}/tokenx/token
+        grant-type: client_credentials
+        scope: sykepengesoknad-backend-api
+        authentication:
+          client-id: client-id
+          client-secret: secretzz
+          client-auth-method: client_secret_basic
 
 elector.get_url: dont_look_for_leader
 
@@ -79,3 +87,4 @@ AAREG_URL: "url"
 EREG_URL: "url"
 PDL_BASE_URL: "url"
 FLEX_SYKETILFELLE_URL: "url"
+SYKEPENGESOKNAD_BACKEND_URL: "url"


### PR DESCRIPTION
## Endringer

Legger til en ny gateway-klient mot `sykepengesoknad-backend` med:
- TokenX-autentisering via `sykepengesoknad-backend-tokenx`
- `GET /api/v2/soknader/sykmelding/{uuid}/harSoknad` endepunkt
- Retry-logikk som utelukker 4xx-feil (ikke retry ved auth-feil)
- Tester med MockWebServer: path, Bearer-token og 401/403-håndtering

## Stacked PRs
- ✅ **PR1** (denne): `feat/har-soknad-klient` → `main`
- ⏳ **PR2**: `ventetid-opt-in` → `feat/har-soknad-klient`
- ⏳ **PR3**: `frontend-endpoints` → `ventetid-opt-in`