### PR TITLE
feat: legg til opprett-opt-in-kall mot sykepengesoknad-backend

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendClient.kt
@@ -1,5 +1,9 @@
 package no.nav.helse.flex.gateways.sykepengesoknadbackend
 
+import no.nav.helse.flex.sykmelding.SykmeldingKafkaMessage
+
 interface SykepengesoknadBackendClient {
     fun harSoknad(sykmeldingUuid: String): Boolean
+
+    fun opprettOptIn(sykmeldingKafkaMessage: SykmeldingKafkaMessage)
 }

--- a/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.flex.gateways.sykepengesoknadbackend
 
+import no.nav.helse.flex.sykmelding.SykmeldingKafkaMessage
 import no.nav.helse.flex.utils.logger
 import org.springframework.http.HttpStatusCode
 import org.springframework.retry.annotation.Retryable
@@ -44,16 +45,45 @@ class SykepengesoknadBackendEksternClient(
         return response.body?.harSoknad
             ?: throw RuntimeException("harSoknad response inneholdt ikke data for sykmelding $sykmeldingUuid")
     }
+
+    @Retryable(exclude = [SykepengesoknadBackendClientException::class])
+    override fun opprettOptIn(sykmeldingKafkaMessage: SykmeldingKafkaMessage) {
+        sykepengesoknadBackendRestClient
+            .post()
+            .uri("/api/v2/soknader/opprett-opt-in")
+            .body(sykmeldingKafkaMessage)
+            .retrieve()
+            .onStatus(HttpStatusCode::isError) { _, httpResponse ->
+                val exception =
+                    when {
+                        httpResponse.statusCode.is4xxClientError -> {
+                            SykepengesoknadBackendClientException(
+                                "Kall til opprett-opt-in feilet med HTTP-${httpResponse.statusCode.value()}",
+                            )
+                        }
+                        else -> {
+                            SykepengesoknadBackendServerException(
+                                "Kall til opprett-opt-in feilet med HTTP-${httpResponse.statusCode.value()}",
+                            )
+                        }
+                    }
+
+                throw exception.also {
+                    log.error(it.message)
+                }
+            }
+            .toEntity<Unit>()
+    }
 }
 
 data class HarSoknadResponse(
     val harSoknad: Boolean,
 )
 
-private class SykepengesoknadBackendClientException(
+class SykepengesoknadBackendClientException(
     message: String,
 ) : RuntimeException(message)
 
-private class SykepengesoknadBackendServerException(
+class SykepengesoknadBackendServerException(
     message: String,
 ) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
+++ b/src/main/kotlin/no/nav/helse/flex/gateways/sykepengesoknadbackend/SykepengesoknadBackendEksternClient.kt
@@ -71,8 +71,7 @@ class SykepengesoknadBackendEksternClient(
                 throw exception.also {
                     log.error(it.message)
                 }
-            }
-            .toEntity<Unit>()
+            }.toEntity<Unit>()
     }
 }
 

--- a/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
@@ -3,15 +3,20 @@ package no.nav.helse.flex.gateways
 import no.nav.helse.flex.gateways.sykepengesoknadbackend.HarSoknadResponse
 import no.nav.helse.flex.gateways.sykepengesoknadbackend.SykepengesoknadBackendClient
 import no.nav.helse.flex.gateways.sykepengesoknadbackend.SykepengesoknadBackendEksternClient
+import no.nav.helse.flex.sykmelding.SykmeldingKafkaMessage
 import no.nav.helse.flex.testconfig.RestClientOppsett
 import no.nav.helse.flex.testconfig.defaultSykepengesoknadBackendDispatcher
 import no.nav.helse.flex.testconfig.simpleDispatcher
+import no.nav.helse.flex.testdata.lagKafkaMetadataDTO
+import no.nav.helse.flex.testdata.lagSykmeldingDto
+import no.nav.helse.flex.testdata.lagSykmeldingStatusKafkaDTO
 import no.nav.helse.flex.utils.serialisertTilString
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.amshove.kluent.*
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
@@ -31,99 +36,185 @@ class SykepengesoknadBackendClientTest {
         sykepengesoknadBackendMockWebServer.dispatcher = defaultSykepengesoknadBackendDispatcher
     }
 
-    @Test
-    fun `burde returnere true når søknad finnes`() {
-        sykepengesoknadBackendMockWebServer.dispatcher =
-            simpleDispatcher {
-                MockResponse()
-                    .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
-                    .addHeader("Content-Type", "application/json")
-            }
-        val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
-        resultat.`should be true`()
+    @Nested
+    inner class HarSoknad {
+        @Test
+        fun `burde returnere true når søknad finnes`() {
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher {
+                    MockResponse()
+                        .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
+                        .addHeader("Content-Type", "application/json")
+                }
+            val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+            resultat.`should be true`()
+        }
+
+        @Test
+        fun `burde returnere false når søknad ikke finnes`() {
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher {
+                    MockResponse()
+                        .setBody(HarSoknadResponse(harSoknad = false).serialisertTilString())
+                        .addHeader("Content-Type", "application/json")
+                }
+            val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+            resultat.`should be false`()
+        }
+
+        @Test
+        fun `burde kaste feil ved 401`() {
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher {
+                    MockResponse()
+                        .setResponseCode(HttpStatus.UNAUTHORIZED.value())
+                        .addHeader("Content-Type", "application/json")
+                }
+            invoking {
+                sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+            } `should throw` RuntimeException::class
+        }
+
+        @Test
+        fun `burde kaste feil ved 403`() {
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher {
+                    MockResponse()
+                        .setResponseCode(HttpStatus.FORBIDDEN.value())
+                        .addHeader("Content-Type", "application/json")
+                }
+            invoking {
+                sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+            } `should throw` RuntimeException::class
+        }
+
+        @Test
+        fun `burde kaste feil ved tom body`() {
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher {
+                    MockResponse()
+                        .addHeader("Content-Type", "application/json")
+                }
+            invoking {
+                sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
+            } `should throw` RuntimeException::class
+        }
+
+        @Test
+        fun `burde sende riktig path`() {
+            var recordedRequest: RecordedRequest? = null
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher { request ->
+                    recordedRequest = request
+                    MockResponse()
+                        .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
+                        .addHeader("Content-Type", "application/json")
+                }
+
+            sykepengesoknadBackendEksternClient.harSoknad("min-sykmelding-id")
+
+            val request = recordedRequest!!
+            request.path `should be equal to` "/api/v2/soknader/sykmelding/min-sykmelding-id/harSoknad"
+        }
+
+        @Test
+        fun `burde sende bearer token i authorization header`() {
+            var recordedRequest: RecordedRequest? = null
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher { request ->
+                    recordedRequest = request
+                    MockResponse()
+                        .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
+                        .addHeader("Content-Type", "application/json")
+                }
+
+            sykepengesoknadBackendEksternClient.harSoknad("test-id")
+
+            val request = recordedRequest!!
+            request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+        }
     }
 
-    @Test
-    fun `burde returnere false når søknad ikke finnes`() {
-        sykepengesoknadBackendMockWebServer.dispatcher =
-            simpleDispatcher {
-                MockResponse()
-                    .setBody(HarSoknadResponse(harSoknad = false).serialisertTilString())
-                    .addHeader("Content-Type", "application/json")
-            }
-        val resultat = sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
-        resultat.`should be false`()
-    }
+    @Nested
+    inner class OpprettOptIn {
+        private val testMelding =
+            SykmeldingKafkaMessage(
+                sykmelding = lagSykmeldingDto(id = "opt-in-sykmelding-id"),
+                kafkaMetadata = lagKafkaMetadataDTO(sykmeldingId = "opt-in-sykmelding-id"),
+                event = lagSykmeldingStatusKafkaDTO(sykmeldingId = "opt-in-sykmelding-id"),
+            )
 
-    @Test
-    fun `burde kaste feil ved 401`() {
-        sykepengesoknadBackendMockWebServer.dispatcher =
-            simpleDispatcher {
-                MockResponse()
-                    .setResponseCode(HttpStatus.UNAUTHORIZED.value())
-                    .addHeader("Content-Type", "application/json")
-            }
-        invoking {
-            sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
-        } `should throw` RuntimeException::class
-    }
+        @Test
+        fun `burde fullføre uten feil ved 200`() {
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher {
+                    MockResponse()
+                        .setResponseCode(HttpStatus.OK.value())
+                        .addHeader("Content-Type", "application/json")
+                }
+            invoking {
+                sykepengesoknadBackendEksternClient.opprettOptIn(testMelding)
+            } `should not throw` AnyException
+        }
 
-    @Test
-    fun `burde kaste feil ved 403`() {
-        sykepengesoknadBackendMockWebServer.dispatcher =
-            simpleDispatcher {
-                MockResponse()
-                    .setResponseCode(HttpStatus.FORBIDDEN.value())
-                    .addHeader("Content-Type", "application/json")
-            }
-        invoking {
-            sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
-        } `should throw` RuntimeException::class
-    }
+        @Test
+        fun `burde kaste feil ved 401`() {
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher {
+                    MockResponse()
+                        .setResponseCode(HttpStatus.UNAUTHORIZED.value())
+                        .addHeader("Content-Type", "application/json")
+                }
+            invoking {
+                sykepengesoknadBackendEksternClient.opprettOptIn(testMelding)
+            } `should throw` RuntimeException::class
+        }
 
-    @Test
-    fun `burde kaste feil ved tom body`() {
-        sykepengesoknadBackendMockWebServer.dispatcher =
-            simpleDispatcher {
-                MockResponse()
-                    .addHeader("Content-Type", "application/json")
-            }
-        invoking {
-            sykepengesoknadBackendEksternClient.harSoknad("sykmelding-uuid")
-        } `should throw` RuntimeException::class
-    }
+        @Test
+        fun `burde kaste feil ved 403`() {
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher {
+                    MockResponse()
+                        .setResponseCode(HttpStatus.FORBIDDEN.value())
+                        .addHeader("Content-Type", "application/json")
+                }
+            invoking {
+                sykepengesoknadBackendEksternClient.opprettOptIn(testMelding)
+            } `should throw` RuntimeException::class
+        }
 
-    @Test
-    fun `burde sende riktig path`() {
-        var recordedRequest: RecordedRequest? = null
-        sykepengesoknadBackendMockWebServer.dispatcher =
-            simpleDispatcher { request ->
-                recordedRequest = request
-                MockResponse()
-                    .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
-                    .addHeader("Content-Type", "application/json")
-            }
+        @Test
+        fun `burde sende til riktig path`() {
+            var recordedRequest: RecordedRequest? = null
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher { request ->
+                    recordedRequest = request
+                    MockResponse()
+                        .setResponseCode(HttpStatus.OK.value())
+                        .addHeader("Content-Type", "application/json")
+                }
 
-        sykepengesoknadBackendEksternClient.harSoknad("min-sykmelding-id")
+            sykepengesoknadBackendEksternClient.opprettOptIn(testMelding)
 
-        val request = recordedRequest!!
-        request.path `should be equal to` "/api/v2/soknader/sykmelding/min-sykmelding-id/harSoknad"
-    }
+            val request = recordedRequest!!
+            request.path `should be equal to` "/api/v2/soknader/opprett-opt-in"
+        }
 
-    @Test
-    fun `burde sende bearer token i authorization header`() {
-        var recordedRequest: RecordedRequest? = null
-        sykepengesoknadBackendMockWebServer.dispatcher =
-            simpleDispatcher { request ->
-                recordedRequest = request
-                MockResponse()
-                    .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
-                    .addHeader("Content-Type", "application/json")
-            }
+        @Test
+        fun `burde sende bearer token i authorization header`() {
+            var recordedRequest: RecordedRequest? = null
+            sykepengesoknadBackendMockWebServer.dispatcher =
+                simpleDispatcher { request ->
+                    recordedRequest = request
+                    MockResponse()
+                        .setResponseCode(HttpStatus.OK.value())
+                        .addHeader("Content-Type", "application/json")
+                }
 
-        sykepengesoknadBackendEksternClient.harSoknad("test-id")
+            sykepengesoknadBackendEksternClient.opprettOptIn(testMelding)
 
-        val request = recordedRequest!!
-        request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+            val request = recordedRequest!!
+            request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+        }
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/testconfig/fakes/SykepengesoknadBackendClientFake.kt
+++ b/src/test/kotlin/no/nav/helse/flex/testconfig/fakes/SykepengesoknadBackendClientFake.kt
@@ -5,6 +5,13 @@ import no.nav.helse.flex.sykmelding.SykmeldingKafkaMessage
 
 class SykepengesoknadBackendClientFake : SykepengesoknadBackendClient {
     val opprettOptInRequests = mutableListOf<SykmeldingKafkaMessage>()
+    private var harSoknadResponse: Boolean = false
+
+    override fun harSoknad(sykmeldingUuid: String): Boolean = harSoknadResponse
+
+    fun setHarSoknad(verdi: Boolean) {
+        harSoknadResponse = verdi
+    }
 
     override fun opprettOptIn(sykmeldingKafkaMessage: SykmeldingKafkaMessage) {
         opprettOptInRequests.add(sykmeldingKafkaMessage)
@@ -14,5 +21,6 @@ class SykepengesoknadBackendClientFake : SykepengesoknadBackendClient {
 
     fun reset() {
         opprettOptInRequests.clear()
+        harSoknadResponse = false
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/testconfig/fakes/SykepengesoknadBackendClientFake.kt
+++ b/src/test/kotlin/no/nav/helse/flex/testconfig/fakes/SykepengesoknadBackendClientFake.kt
@@ -1,17 +1,18 @@
 package no.nav.helse.flex.testconfig.fakes
 
 import no.nav.helse.flex.gateways.sykepengesoknadbackend.SykepengesoknadBackendClient
+import no.nav.helse.flex.sykmelding.SykmeldingKafkaMessage
 
 class SykepengesoknadBackendClientFake : SykepengesoknadBackendClient {
-    private var harSoknadResponse = false
+    val opprettOptInRequests = mutableListOf<SykmeldingKafkaMessage>()
 
-    override fun harSoknad(sykmeldingUuid: String): Boolean = harSoknadResponse
-
-    fun setHarSoknad(harSoknad: Boolean) {
-        harSoknadResponse = harSoknad
+    override fun opprettOptIn(sykmeldingKafkaMessage: SykmeldingKafkaMessage) {
+        opprettOptInRequests.add(sykmeldingKafkaMessage)
     }
 
+    fun antallOpprettOptInKall(): Int = opprettOptInRequests.size
+
     fun reset() {
-        harSoknadResponse = false
+        opprettOptInRequests.clear()
     }
 }


### PR DESCRIPTION
## Endringer

Bygger videre på PR1 og legger til:
- `opprettOptIn(SykmeldingKafkaMessage)` metode i `SykepengesoknadBackendClient`
- `POST /api/v2/soknader/opprett-opt-in` implementasjon med TokenX og retry
- Oppdatert fake-klient for integrasjonstester

## Stacked PRs
- ✅ **PR1**: `feat/har-soknad-klient` → `main` (#566)
- ✅ **PR2** (denne): `ventetid-opt-in` → `feat/har-soknad-klient`
- ⏳ **PR3**: `frontend-endpoints` → `ventetid-opt-in`

> ⚠️ Merge PR1 først, deretter oppdater base til `main` for denne PRen.