### PR TITLE
feat: legg til frontend-endepunkter for har-soknad og opt-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ out/
 *.DS_Store
 
 bin/
+.cplt.toml

--- a/src/main/kotlin/no/nav/helse/flex/api/SykmeldingController.kt
+++ b/src/main/kotlin/no/nav/helse/flex/api/SykmeldingController.kt
@@ -7,23 +7,30 @@ import no.nav.helse.flex.config.IdentService
 import no.nav.helse.flex.config.PersonIdenter
 import no.nav.helse.flex.config.TOKENX
 import no.nav.helse.flex.config.TokenxValidering
+import no.nav.helse.flex.gateways.KafkaMetadataDTO
+import no.nav.helse.flex.gateways.sykepengesoknadbackend.HarSoknadResponse
+import no.nav.helse.flex.gateways.sykepengesoknadbackend.SykepengesoknadBackendClient
 import no.nav.helse.flex.gateways.syketilfelle.ErUtenforVentetidResponse
 import no.nav.helse.flex.gateways.syketilfelle.SyketilfelleClient
 import no.nav.helse.flex.narmesteleder.domain.NarmesteLeder
 import no.nav.helse.flex.sykmelding.FinnTidligereArbeidsgivereForArbeidsledigService
 import no.nav.helse.flex.sykmelding.ISykmeldingRepository
+import no.nav.helse.flex.sykmelding.SykmeldingKafkaMessage
 import no.nav.helse.flex.sykmelding.SykmeldingLeser
 import no.nav.helse.flex.sykmelding.SykmeldingVentetidService
 import no.nav.helse.flex.sykmeldinghendelse.Arbeidssituasjon
 import no.nav.helse.flex.sykmeldinghendelse.HendelseStatus
+import no.nav.helse.flex.sykmeldinghendelse.SYKMELDINGSTATUS_LEESAH_SOURCE
 import no.nav.helse.flex.sykmeldinghendelse.SykmeldingHendelseHandterer
 import no.nav.helse.flex.sykmeldinghendelse.TidligereArbeidsgiver
+import no.nav.helse.flex.tsmsykmeldingstatus.SykmeldingHendelseTilKafkaKonverterer
 import no.nav.helse.flex.utils.logger
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.time.OffsetDateTime
 
 @RestController
 class SykmeldingController(
@@ -41,6 +48,7 @@ class SykmeldingController(
     @param:Value("\${SYKEPENGESOKNAD_CLIENT_ID}")
     private val sykepengesoknadClientId: String,
     private val sykmeldingVentetidService: SykmeldingVentetidService,
+    private val sykepengesoknadBackendClient: SykepengesoknadBackendClient,
 ) {
     private val logger = logger()
 
@@ -191,6 +199,58 @@ class SykmeldingController(
             )
 
         return ResponseEntity.ok(ErForsteSykmeldingResponse(erForsteSykmelding = erForsteSykmelding))
+    }
+
+    @GetMapping("/api/v1/sykmeldinger/{sykmeldingId}/har-soknad")
+    @ProtectedWithClaims(
+        issuer = TOKENX,
+        combineWithOr = true,
+        claimMap = ["acr=Level4", "acr=idporten-loa-high"],
+    )
+    fun getHarSoknad(
+        @PathVariable("sykmeldingId") sykmeldingId: String,
+    ): ResponseEntity<HarSoknadResponse> {
+        val identer = tokenxValidering.hentIdenter(dittSykefravaerFrontendClientId)
+        sykmeldingLeser.hentSykmelding(sykmeldingId = sykmeldingId, identer = identer)
+
+        val harSoknad = sykepengesoknadBackendClient.harSoknad(sykmeldingId)
+        return ResponseEntity.ok(HarSoknadResponse(harSoknad = harSoknad))
+    }
+
+    @PostMapping("/api/v1/sykmeldinger/{sykmeldingId}/opt-in")
+    @ProtectedWithClaims(
+        issuer = TOKENX,
+        combineWithOr = true,
+        claimMap = ["acr=Level4", "acr=idporten-loa-high"],
+    )
+    fun postOptIn(
+        @PathVariable("sykmeldingId") sykmeldingId: String,
+    ): ResponseEntity<Unit> {
+        val identer = tokenxValidering.hentIdenter(dittSykefravaerFrontendClientId)
+        val sykmelding = sykmeldingLeser.hentSykmelding(sykmeldingId = sykmeldingId, identer = identer)
+
+        val sykmeldingDto = sykmeldingDtoKonverterer.konverter(sykmelding)
+        val kafkaMetadata =
+            KafkaMetadataDTO(
+                sykmeldingId = sykmelding.sykmeldingId,
+                timestamp = OffsetDateTime.now(),
+                fnr = sykmelding.pasientFnr,
+                source = SYKMELDINGSTATUS_LEESAH_SOURCE,
+            )
+        val event =
+            SykmeldingHendelseTilKafkaKonverterer.konverterSykmeldingHendelseTilKafkaDTO(
+                sykmeldingHendelse = sykmelding.sisteHendelse(),
+                sykmeldingId = sykmelding.sykmeldingId,
+            )
+        val sykmeldingKafkaMessage =
+            SykmeldingKafkaMessage(
+                kafkaMetadata = kafkaMetadata,
+                event = event,
+                sykmelding = sykmeldingDto,
+            )
+
+        sykepengesoknadBackendClient.opprettOptIn(sykmeldingKafkaMessage)
+        return ResponseEntity.noContent().build()
     }
 
     @PostMapping("/api/v1/sykmeldinger/{sykmeldingId}/send")

--- a/src/test/kotlin/no/nav/helse/flex/api/SykmeldingControllerTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/api/SykmeldingControllerTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.helse.flex.api.dto.*
 import no.nav.helse.flex.arbeidsforhold.lagArbeidsforhold
 import no.nav.helse.flex.arbeidsgiverdetaljer.domain.ArbeidsgiverDetaljer
+import no.nav.helse.flex.gateways.sykepengesoknadbackend.HarSoknadResponse
 import no.nav.helse.flex.gateways.syketilfelle.ErUtenforVentetidResponse
 import no.nav.helse.flex.gateways.syketilfelle.FomTomPeriode
 import no.nav.helse.flex.gateways.syketilfelle.SammeVentetidPeriode
@@ -15,6 +16,7 @@ import no.nav.helse.flex.sykmeldinghendelse.HendelseStatus
 import no.nav.helse.flex.sykmeldinghendelse.SporsmalSvar
 import no.nav.helse.flex.sykmeldinghendelse.TidligereArbeidsgiver
 import no.nav.helse.flex.testconfig.FakesTestOppsett
+import no.nav.helse.flex.testconfig.fakes.SykepengesoknadBackendClientFake
 import no.nav.helse.flex.testconfig.fakes.SyketilfelleClientFake
 import no.nav.helse.flex.testdata.*
 import no.nav.helse.flex.testutils.tokenxToken
@@ -52,6 +54,9 @@ class SykmeldingControllerTest : FakesTestOppsett() {
 
     @Autowired
     lateinit var syketilfelleClient: SyketilfelleClientFake
+
+    @Autowired
+    lateinit var sykepengesoknadBackendClient: SykepengesoknadBackendClientFake
 
     @Value("\${DITT_SYKEFRAVAER_FRONTEND_CLIENT_ID}")
     lateinit var dittSykefravaerFrontendClientId: String
@@ -993,6 +998,147 @@ class SykmeldingControllerTest : FakesTestOppsett() {
                 orgnummer shouldBeEqualTo "orgnr"
                 orgNavn shouldBeEqualTo "Navn"
             }
+        }
+    }
+
+    @Nested
+    inner class HarSoknadEndepunkt {
+        @AfterEach
+        fun reset() {
+            sykepengesoknadBackendClient.reset()
+        }
+
+        @Test
+        fun `burde returnere harSoknad fra sykepengesoknad-backend`() {
+            sykmeldingRepository.save(
+                lagSykmelding(sykmeldingGrunnlag = lagSykmeldingGrunnlag(id = "1", pasient = lagPasient(fnr = "fnr"))),
+            )
+            sykepengesoknadBackendClient.setHarSoknad(true)
+
+            val result =
+                mockMvc
+                    .perform(
+                        MockMvcRequestBuilders
+                            .get("/api/v1/sykmeldinger/1/har-soknad")
+                            .authorizationHeader(oauth2Server.tokenxToken(fnr = "fnr", clientId = defaultClientId))
+                            .contentType(MediaType.APPLICATION_JSON),
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                    .andReturn()
+                    .response.contentAsString
+
+            val response: HarSoknadResponse = objectMapper.readValue(result)
+            response.harSoknad `should be equal to` true
+        }
+
+        @Test
+        fun `burde returnere false om søknad ikke finnes`() {
+            sykmeldingRepository.save(
+                lagSykmelding(sykmeldingGrunnlag = lagSykmeldingGrunnlag(id = "1", pasient = lagPasient(fnr = "fnr"))),
+            )
+            sykepengesoknadBackendClient.setHarSoknad(false)
+
+            val result =
+                mockMvc
+                    .perform(
+                        MockMvcRequestBuilders
+                            .get("/api/v1/sykmeldinger/1/har-soknad")
+                            .authorizationHeader(oauth2Server.tokenxToken(fnr = "fnr", clientId = defaultClientId))
+                            .contentType(MediaType.APPLICATION_JSON),
+                    ).andExpect(MockMvcResultMatchers.status().isOk)
+                    .andReturn()
+                    .response.contentAsString
+
+            val response: HarSoknadResponse = objectMapper.readValue(result)
+            response.harSoknad `should be equal to` false
+        }
+
+        @Test
+        fun `burde returnere 404 om sykmelding ikke finnes`() =
+            sjekkFår404NårSykmeldingenIkkeFinnes { sykmeldingId -> "/api/v1/sykmeldinger/$sykmeldingId/har-soknad" }
+
+        @Test
+        fun `burde returnere 403 for feil fnr`() =
+            sjekkAtFeilerDersomSykmeldingHarFeilFnr { sykmeldingId -> "/api/v1/sykmeldinger/$sykmeldingId/har-soknad" }
+
+        @Test
+        fun `burde avvise kall fra sykepengesoknad client-id`() {
+            sykmeldingRepository.save(
+                lagSykmelding(sykmeldingGrunnlag = lagSykmeldingGrunnlag(id = "1", pasient = lagPasient(fnr = "fnr"))),
+            )
+            sjekkStatus(
+                url = "/api/v1/sykmeldinger/1/har-soknad",
+                token = oauth2Server.tokenxToken(fnr = "fnr", clientId = sykepengesoknadClientId),
+                expectedStatus = HttpStatus.FORBIDDEN,
+            )
+        }
+    }
+
+    @Nested
+    inner class OptInEndepunkt {
+        @AfterEach
+        fun reset() {
+            sykepengesoknadBackendClient.reset()
+        }
+
+        @Test
+        fun `burde kalle opprettOptIn og returnere 204`() {
+            sykmeldingRepository.save(
+                lagSykmelding(sykmeldingGrunnlag = lagSykmeldingGrunnlag(id = "1", pasient = lagPasient(fnr = "fnr"))),
+            )
+
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/api/v1/sykmeldinger/1/opt-in")
+                        .authorizationHeader(oauth2Server.tokenxToken(fnr = "fnr", clientId = defaultClientId))
+                        .contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(MockMvcResultMatchers.status().isNoContent)
+
+            sykepengesoknadBackendClient.antallOpprettOptInKall() `should be equal to` 1
+        }
+
+        @Test
+        fun `burde videresende sykmeldingId i opprettOptIn-kallet`() {
+            sykmeldingRepository.save(
+                lagSykmelding(sykmeldingGrunnlag = lagSykmeldingGrunnlag(id = "1", pasient = lagPasient(fnr = "fnr"))),
+            )
+
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/api/v1/sykmeldinger/1/opt-in")
+                        .authorizationHeader(oauth2Server.tokenxToken(fnr = "fnr", clientId = defaultClientId))
+                        .contentType(MediaType.APPLICATION_JSON),
+                ).andExpect(MockMvcResultMatchers.status().isNoContent)
+
+            val request = sykepengesoknadBackendClient.opprettOptInRequests.first()
+            request.kafkaMetadata.sykmeldingId `should be equal to` "1"
+            request.kafkaMetadata.fnr `should be equal to` "fnr"
+        }
+
+        @Test
+        fun `burde returnere 404 om sykmelding ikke finnes`() =
+            sjekkFår404NårSykmeldingenIkkeFinnes(
+                httpMethod = HttpMethod.POST,
+            ) { sykmeldingId -> "/api/v1/sykmeldinger/$sykmeldingId/opt-in" }
+
+        @Test
+        fun `burde returnere 403 for feil fnr`() =
+            sjekkAtFeilerDersomSykmeldingHarFeilFnr(
+                httpMethod = HttpMethod.POST,
+            ) { sykmeldingId -> "/api/v1/sykmeldinger/$sykmeldingId/opt-in" }
+
+        @Test
+        fun `burde avvise kall fra sykepengesoknad client-id`() {
+            sykmeldingRepository.save(
+                lagSykmelding(sykmeldingGrunnlag = lagSykmeldingGrunnlag(id = "1", pasient = lagPasient(fnr = "fnr"))),
+            )
+            sjekkStatus(
+                url = "/api/v1/sykmeldinger/1/opt-in",
+                httpMethod = HttpMethod.POST,
+                token = oauth2Server.tokenxToken(fnr = "fnr", clientId = sykepengesoknadClientId),
+                expectedStatus = HttpStatus.FORBIDDEN,
+            )
         }
     }
 

--- a/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/gateways/SykepengesoknadBackendClientTest.kt
@@ -217,4 +217,21 @@ class SykepengesoknadBackendClientTest {
             request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
         }
     }
+
+    @Test
+    fun `burde sende bearer token i authorization header`() {
+        var recordedRequest: RecordedRequest? = null
+        sykepengesoknadBackendMockWebServer.dispatcher =
+            simpleDispatcher { request ->
+                recordedRequest = request
+                MockResponse()
+                    .setBody(HarSoknadResponse(harSoknad = true).serialisertTilString())
+                    .addHeader("Content-Type", "application/json")
+            }
+
+        sykepengesoknadBackendEksternClient.harSoknad("test-id")
+
+        val request = recordedRequest!!
+        request.headers["Authorization"]!!.shouldStartWith("Bearer ey")
+    }
 }


### PR DESCRIPTION
## Endringer

Legger til to nye endepunkter i `SykmeldingController` for frontend-klienter:

### `GET /api/v1/sykmeldinger/{uuid}/har-soknad`
- Validerer TokenX-token (kun `ditt-sykefravaer-frontend`)
- Verifiserer at brukeren eier sykmeldingen
- Kaller `sykepengesoknadBackendClient.harSoknad(uuid)`
- Returnerer `{ harSoknad: Boolean }`

### `POST /api/v1/sykmeldinger/{uuid}/opt-in`
- Validerer TokenX-token (kun `ditt-sykefravaer-frontend`)
- Verifiserer at brukeren eier sykmeldingen
- Bygger `SykmeldingKafkaMessage` fra sykmelding
- Kaller `sykepengesoknadBackendClient.opprettOptIn(message)`
- Returnerer `204 No Content`

### Tester
- Suksess-scenario for begge endepunkter
- 404 når sykmelding ikke finnes
- 403 ved feil fnr
- 403 ved ugyldig client-id (sykepengesoknad avvises)

## Stacked PRs
- ✅ **PR1**: `feat/har-soknad-klient` → `main` (#566)
- ✅ **PR2**: `ventetid-opt-in` → `feat/har-soknad-klient` (#568)
- ✅ **PR3** (denne): `frontend-endpoints` → `ventetid-opt-in`

> ⚠️ Merge PR1 og PR2 først, deretter rebase denne mot `main`.