### PR TITLE
Fikser ktlint innstillinger slik at when entry ikke trenger så mye luft

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,3 +2,5 @@
 indent_size=4
 insert_final_newline=true
 ktlint_standard_no-wildcard-imports=disabled
+ktlint_standard_when-entry-bracing = disabled
+ktlint_standard_blank-line-between-when-conditions = disabled


### PR DESCRIPTION
Før (uønsket formattering med braces + luft)
```
when (ex) {
    is SykmeldingIkkeFunnetException -> {
        skapResponseEntity(HttpStatus.NOT_FOUND)
    }

    is SykmeldingErIkkeDinException -> {
        skapResponseEntity(HttpStatus.FORBIDDEN)
    }

    is UgyldigOptinException -> {
        skapResponseEntity(HttpStatus.CONFLICT)
    }
}
```

Etter (ønsket formattering uten braces og uten tomlinjer)
```
when (ex) {
    is SykmeldingIkkeFunnetException -> skapResponseEntity(HttpStatus.NOT_FOUND)
    is SykmeldingErIkkeDinException -> skapResponseEntity(HttpStatus.FORBIDDEN)
    is UgyldigOptinException -> skapResponseEntity(HttpStatus.CONFLICT)
}
```